### PR TITLE
feat(api): 更新用户信息获取接口并扩展用户模型

### DIFF
--- a/src/components/layout/authenticated-layout.tsx
+++ b/src/components/layout/authenticated-layout.tsx
@@ -2,7 +2,7 @@ import Cookies from 'js-cookie'
 import { useEffect } from 'react'
 import { Outlet, useMatches } from '@tanstack/react-router'
 import { useQuery } from '@tanstack/react-query'
-import { fetchCurrentUser } from '@/lib/api'
+import { fetchTalentMe } from '@/lib/api'
 import { useAuthStore } from '@/stores/authStore'
 import { cn } from '@/lib/utils'
 import { SearchProvider } from '@/context/search-context'
@@ -22,7 +22,7 @@ export function AuthenticatedLayout({ children }: Props) {
 
   const { data, error } = useQuery({
     queryKey: ['current-user'],
-    queryFn: fetchCurrentUser,
+    queryFn: fetchTalentMe,
     staleTime: 5 * 60 * 1000,
     refetchOnWindowFocus: false,
     retry: false,

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -85,7 +85,7 @@ export interface CurrentUserResponse {
 
 export async function fetchCurrentUser(): Promise<CurrentUserResponse> {
   // 该接口直接返回用户对象（无通用外层包装）。拦截器已将响应解包为数据对象。
-  return api.get('/users/me') as unknown as Promise<CurrentUserResponse>
+  return api.get('/talent/me') as unknown as Promise<CurrentUserResponse>
 }
 
 export async function fetchTalentMe(): Promise<Talent> {

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -46,8 +46,11 @@ export interface Talent extends TalentParams {
   is_onboard: boolean
   id: number
   username: string
+  full_name: string
   phone_number: string
+  birth_month: string
   avatar_url: string
+  is_superuser: boolean
 }
 
 export interface InviteInfo {


### PR DESCRIPTION
- 将 fetchCurrentUser 函数的 API路径从 '/users/me' 修改为 '/talent/me'
- 在 AuthenticatedLayout 组件中使用 fetchTalentMe 替代 fetchCurrentUser
- 在 authStore 中扩展 User 接口，增加 full_name、birth_month 和 is_superuser 字段

## 描述

<!-- 请清晰、简洁地描述此 PR 的变更内容，并说明相关的动机与背景。 -->

## 变更类型

<!-- 你的代码为本项目引入了哪些类型的变更？在适用的选项中用 `x` 标注 -->

- [ ] Bug 修复（非破坏性更改，用于修复问题）
- [ ] 新功能（非破坏性更改，增加新功能）
- [ ] 其他（未在以上列出的更改）

## 清单

<!-- 提交 PR 前请遵循以下清单，并在完成项目前加上 [x]。也可以在创建 PR 后补充。此清单用于帮助我们在合并前进行检查。 -->

- [ ] 我已阅读 [贡献指南](https://github.com/satnaing/shadcn-admin/blob/main/.github/CONTRIBUTING.md)

## 进一步说明

<!-- 如果这是较大或复杂的变更，请解释你为何选择该方案，以及你考虑过的替代方案等。 -->

## 关联的 Issue

<!-- 如果此 PR 与现有 Issue 相关，请在此处进行链接。 -->

关闭：#<!-- 相关 Issue 编号（如适用） -->