### PR TITLE
refactor(resume): 移除教育经历中的重复学历学位字段

### DIFF
--- a/src/features/resume/data/config.ts
+++ b/src/features/resume/data/config.ts
@@ -127,8 +127,7 @@ export const resumeFormConfig: {
         itemFields: [
           { key: 'institution', label: '学校/机构', component: 'input', placeholder: '例如：某某大学' },
           { key: 'major', label: '专业', component: 'input', placeholder: '例如：计算机科学' },
-          { key: 'degreeTypeText', label: '学历/学位', component: 'input', placeholder: '例如：本科/硕士/博士' },
-          { key: 'degreeType', label: '学历/学位(选择)', component: 'select', optionsKey: 'degreeType', placeholder: '请选择学历/学位' },
+          { key: 'degreeType', label: '学历/学位', component: 'select', optionsKey: 'degreeType', placeholder: '请选择学历/学位' },
           { key: 'degreeStatus', label: '获取状态', component: 'select', optionsKey: 'degreeStatus', placeholder: '请选择状态' },
           { key: 'startDate', label: '开始时间', component: 'input', placeholder: '例如：2018/09' },
           { key: 'endDate', label: '结束时间', component: 'input', placeholder: '例如：2021/08' },


### PR DESCRIPTION
- 删除了 'degreeTypeText' 字段，保留 'degreeType' 选择框
- 优化了教育经历的输入结构，避免用户重复填写学历学位信息

## 描述

<!-- 请清晰、简洁地描述此 PR 的变更内容，并说明相关的动机与背景。 -->

## 变更类型

<!-- 你的代码为本项目引入了哪些类型的变更？在适用的选项中用 `x` 标注 -->

- [ ] Bug 修复（非破坏性更改，用于修复问题）
- [ ] 新功能（非破坏性更改，增加新功能）
- [ ] 其他（未在以上列出的更改）

## 清单

<!-- 提交 PR 前请遵循以下清单，并在完成项目前加上 [x]。也可以在创建 PR 后补充。此清单用于帮助我们在合并前进行检查。 -->

- [ ] 我已阅读 [贡献指南](https://github.com/satnaing/shadcn-admin/blob/main/.github/CONTRIBUTING.md)

## 进一步说明

<!-- 如果这是较大或复杂的变更，请解释你为何选择该方案，以及你考虑过的替代方案等。 -->

## 关联的 Issue

<!-- 如果此 PR 与现有 Issue 相关，请在此处进行链接。 -->

关闭：#<!-- 相关 Issue 编号（如适用） -->