### PR TITLE
refactor(interview): 优化获取面试节点 ID 的逻辑并调整面试流程

### DIFF
--- a/src/features/interview/api.ts
+++ b/src/features/interview/api.ts
@@ -132,9 +132,24 @@ export function useJobApplyWorkflow(jobApplyId: string | number | null, enabled 
 
 // Helper: get INTERVIEW node id from workflow
 export function getInterviewNodeId(workflow?: JobApplyWorkflowResponse | null): string | number | undefined {
-  if (!workflow || !Array.isArray(workflow.nodes)) return undefined
-  const node = workflow.nodes.find((n) => n?.node_type === 'INTERVIEW')
-  return node?.id as string | number | undefined
+  if (!workflow) return undefined
+  const nodes: JobApplyWorkflowNode[] = Array.isArray(workflow.nodes) ? workflow.nodes : []
+  const isInterviewLike = (n: JobApplyWorkflowNode): boolean => {
+    const type = String(n?.node_type ?? '').toUpperCase()
+    const key = String(n?.node_key ?? '')
+    const name = String(n?.node_name ?? '')
+    const lower = `${key} ${name}`.toLowerCase()
+    return (
+      type === 'INTERVIEW' ||
+      key === 'Interview' ||
+      lower.includes('interview') ||
+      name.includes('面试')
+    )
+  }
+  const hit = nodes.find((n) => isInterviewLike(n))
+  if (hit?.id != null) return hit.id
+  if (workflow.current_node_id != null) return workflow.current_node_id
+  return undefined
 }
 
 // Node action API

--- a/src/features/interview/index.tsx
+++ b/src/features/interview/index.tsx
@@ -28,6 +28,8 @@ export default function InterviewPage({ jobId, jobApplyId, interviewNodeId }: In
   const navigatedRef = useRef(false)
   const endedRef = useRef(false)
 
+  // 直接使用 URL 传入的 interview_node_id
+
   // 当拿到 token/serverUrl 时，连接房间；离开时断开
   useEffect(() => {
     if (!data?.token || !data?.serverUrl) return
@@ -99,6 +101,11 @@ export default function InterviewPage({ jobId, jobApplyId, interviewNodeId }: In
       if (!hasEverConnectedRef.current || navigatedRef.current) return
       navigatedRef.current = true
       const interviewId = (data as { interviewId?: string | number } | undefined)?.interviewId
+      try {
+        if (interviewNodeId) {
+          await postNodeAction({ node_id: interviewNodeId, trigger: NodeActionTrigger.Submit, result_data: {} })
+        }
+      } catch { /* ignore */ }
       if (interviewId) {
         setTimeout(() => {
           // TIPS： 这里使用原生API而非route跳转，因为这样可以低成本解决设备权限未被释放的问题


### PR DESCRIPTION
- 重构 getInterviewNodeId 函数，增加对面试节点的多种判断条件
- 在面试准备页面中使用 useMemo 获取面试节点 ID
- 调整面试流程中的导航逻辑，直接使用获取的面试节点 ID
- 在重新面试功能中，移除不必要的成功判断

## 描述

<!-- 请清晰、简洁地描述此 PR 的变更内容，并说明相关的动机与背景。 -->

## 变更类型

<!-- 你的代码为本项目引入了哪些类型的变更？在适用的选项中用 `x` 标注 -->

- [ ] Bug 修复（非破坏性更改，用于修复问题）
- [ ] 新功能（非破坏性更改，增加新功能）
- [ ] 其他（未在以上列出的更改）

## 清单

<!-- 提交 PR 前请遵循以下清单，并在完成项目前加上 [x]。也可以在创建 PR 后补充。此清单用于帮助我们在合并前进行检查。 -->

- [ ] 我已阅读 [贡献指南](https://github.com/satnaing/shadcn-admin/blob/main/.github/CONTRIBUTING.md)

## 进一步说明

<!-- 如果这是较大或复杂的变更，请解释你为何选择该方案，以及你考虑过的替代方案等。 -->

## 关联的 Issue

<!-- 如果此 PR 与现有 Issue 相关，请在此处进行链接。 -->

关闭：#<!-- 相关 Issue 编号（如适用） -->