### PR TITLE
feat(auth): 增加用户显示名称并调整首页路由

### DIFF
--- a/src/components/layout/authenticated-layout.tsx
+++ b/src/components/layout/authenticated-layout.tsx
@@ -41,6 +41,7 @@ export function AuthenticatedLayout({ children }: Props) {
       id: data.id,
       email: data.email,
       full_name: data.full_name,
+      username: (data as unknown as { username?: string }).username,
       is_active: data.is_active,
       is_superuser: data.is_superuser,
       is_onboard: data.is_onboard,

--- a/src/components/layout/data/sidebar-data.ts
+++ b/src/components/layout/data/sidebar-data.ts
@@ -11,7 +11,7 @@ export const sidebarData: SidebarData = {
   teams: [],
   navGroups: [
     {
-      title: '通用',
+      title: '',
       items: [
         {
           title: '主页',

--- a/src/features/home/index.tsx
+++ b/src/features/home/index.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useNavigate } from '@tanstack/react-router'
+import { useAuthStore } from '@/stores/authStore'
 import { IconX, IconHelp } from '@tabler/icons-react'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
@@ -21,6 +22,8 @@ import { toast } from 'sonner'
 
 export default function HomeViewPage() {
   const navigate = useNavigate()
+  const authUser = useAuthStore((s) => s.auth.user)
+  const displayName = authUser?.full_name || authUser?.username || ''
   const { data: taskList = [], isLoading: loadingTasks } =
     useImportantTasksQuery()
   const [dismissed, setDismissed] = useState<Record<string, boolean>>({})
@@ -69,7 +72,7 @@ export default function HomeViewPage() {
       <Main fixed>
         <div className='space-y-0.5'>
           <h1 className='text-2xl font-bold tracking-tight md:text-3xl'>
-            欢迎回来，
+            欢迎回来{displayName ? `，${displayName}` : ''}
           </h1>
           <p className='text-muted-foreground'>查看你的任务与申请进度</p>
         </div>

--- a/src/routes/_authenticated/index.tsx
+++ b/src/routes/_authenticated/index.tsx
@@ -3,7 +3,7 @@ import { createFileRoute, redirect } from '@tanstack/react-router'
 export const Route = createFileRoute('/_authenticated/')({
   beforeLoad: ({ location }) => {
     if (location.pathname === '/' || location.pathname === '') {
-      throw redirect({ to: '/jobs' })
+      throw redirect({ to: '/home' })
     }
   },
 })

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -8,6 +8,7 @@ interface AuthUser {
   id: number
   email: string
   full_name: string
+  username?: string
   is_active: boolean
   is_superuser: boolean
   is_onboard: boolean


### PR DESCRIPTION
- 在 AuthenticatedLayout 和 AuthStore 中添加用户名字段
- 在首页动态显示用户全名或用户名
- 修改默认路由从 /jobs 改为 /home
- 移除通用导航栏标题

## 描述

<!-- 请清晰、简洁地描述此 PR 的变更内容，并说明相关的动机与背景。 -->

## 变更类型

<!-- 你的代码为本项目引入了哪些类型的变更？在适用的选项中用 `x` 标注 -->

- [ ] Bug 修复（非破坏性更改，用于修复问题）
- [ ] 新功能（非破坏性更改，增加新功能）
- [ ] 其他（未在以上列出的更改）

## 清单

<!-- 提交 PR 前请遵循以下清单，并在完成项目前加上 [x]。也可以在创建 PR 后补充。此清单用于帮助我们在合并前进行检查。 -->

- [ ] 我已阅读 [贡献指南](https://github.com/satnaing/shadcn-admin/blob/main/.github/CONTRIBUTING.md)

## 进一步说明

<!-- 如果这是较大或复杂的变更，请解释你为何选择该方案，以及你考虑过的替代方案等。 -->

## 关联的 Issue

<!-- 如果此 PR 与现有 Issue 相关，请在此处进行链接。 -->

关闭：#<!-- 相关 Issue 编号（如适用） -->