### PR TITLE
fix(interview): 添加调试日志以跟踪设备ID

### DIFF
--- a/src/features/interview/prepare.tsx
+++ b/src/features/interview/prepare.tsx
@@ -130,6 +130,7 @@ enum ViewMode {
       const preferredSpk = getPreferredDeviceId('audiooutput')
       if (!preferredSpk && spk.activeDeviceId) {
         void setPreferredDeviceIdSmart('audiooutput', spk.activeDeviceId, spk.devices)
+        setDisplaySpkDeviceId(getPreferredDeviceId('audiooutput') || '')
       }
     }, [spk.activeDeviceId, spk.devices])
 
@@ -187,6 +188,8 @@ enum ViewMode {
               isControlled
               value={displaySpkDeviceId}
               onValueChange={(v) => {
+                // eslint-disable-next-line no-console
+                console.log('切换设置扬声器设备', v)
                 // 立即更新显示值
                 setDisplaySpkDeviceId(v)
                 

--- a/src/lib/devices.ts
+++ b/src/lib/devices.ts
@@ -98,6 +98,8 @@ export async function resolveRealDeviceId(
 
     // 方法1: 通过设备名称匹配
     const nameMatchedId = await resolveDefaultDeviceByName(kind, devices)
+    // eslint-disable-next-line no-console
+    console.log('nameMatchedId', nameMatchedId)
     if (nameMatchedId) {
       return nameMatchedId
     }
@@ -157,6 +159,8 @@ export async function setPreferredDeviceIdSmart(
   // 如果是 'default'，尝试获取真实的设备ID
   if (deviceId === 'default') {
     const realId = await resolveRealDeviceId(kind, devices)
+    // eslint-disable-next-line no-console
+    console.log('realId 实际设备ID', realId)
     const finalId = realId || deviceId
     setPreferredDeviceId(kind, finalId)
   } else {


### PR DESCRIPTION
- 在扬声器设备ID的设置和解析过程中添加调试日志，便于监控设备状态
- 确保在设备切换和选择时能够更好地跟踪实际设备ID和名称匹配ID

