### PR TITLE
feat(apm): 添加思考时长监控

### DIFF
--- a/src/features/interview/index.tsx
+++ b/src/features/interview/index.tsx
@@ -285,7 +285,7 @@ export default function InterviewPage({ jobId, jobApplyId, interviewNodeId }: In
             <div className='h-full'>
               <RoomContext.Provider value={roomRef.current}>
                 <RoomAudioRenderer />
-                <SessionView disabled={false} sessionStarted className='h-full' onRequestEnd={() => setConfirmEndOpen(true)} onDisconnect={performEndInterview} recordingStatus={recordStatus?.status} />
+                <SessionView disabled={false} sessionStarted className='h-full' onRequestEnd={() => setConfirmEndOpen(true)} onDisconnect={performEndInterview} recordingStatus={recordStatus?.status} interviewId={data?.interviewId} />
               </RoomContext.Provider>
             </div>
           ) : (

--- a/src/lib/apm.ts
+++ b/src/lib/apm.ts
@@ -57,6 +57,22 @@ export function reportRecordFail(roomName: string): void {
   })
 }
 
+/**
+ * Report a single thinking duration for the interview session.
+ * Event name format: thinking_<round>_ms, metrics.value_ms = duration in ms
+ */
+export function reportThinkingDuration(round: number, durationMs: number, extra?: Record<string, string>): void {
+  if (!apmClient) return
+  const safeRound = Math.max(1, Math.floor(round))
+  const safeDuration = Math.max(0, Math.round(durationMs))
+  apmClient('sendEvent', {
+    name: `thinking_${safeRound}_ms`,
+    metrics: { value_ms: safeDuration },
+    categories: { page: 'session', ...(extra ?? {}) },
+    type: 'event',
+  })
+}
+
 export function initApm(): void {
   if (initialized) return
 


### PR DESCRIPTION
- 新增 reportThinkingDuration 函数用于上报思考时长
- 在 SessionView 组件中实现思考时长的计算和上报
- 通过 performance.now() 记录思考开始和结束时间
- 每轮思考结束后上报思考时长和轮次
- 可选地添加面试 ID 作为额外信息

## 描述

<!-- 请清晰、简洁地描述此 PR 的变更内容，并说明相关的动机与背景。 -->

## 变更类型

<!-- 你的代码为本项目引入了哪些类型的变更？在适用的选项中用 `x` 标注 -->

- [ ] Bug 修复（非破坏性更改，用于修复问题）
- [ ] 新功能（非破坏性更改，增加新功能）
- [ ] 其他（未在以上列出的更改）

## 清单

<!-- 提交 PR 前请遵循以下清单，并在完成项目前加上 [x]。也可以在创建 PR 后补充。此清单用于帮助我们在合并前进行检查。 -->

- [ ] 我已阅读 [贡献指南](https://github.com/satnaing/shadcn-admin/blob/main/.github/CONTRIBUTING.md)

## 进一步说明

<!-- 如果这是较大或复杂的变更，请解释你为何选择该方案，以及你考虑过的替代方案等。 -->

## 关联的 Issue

<!-- 如果此 PR 与现有 Issue 相关，请在此处进行链接。 -->

关闭：#<!-- 相关 Issue 编号（如适用） -->