### PR TITLE
refactor(interview): 更新面试结束相关文案

### DIFF
--- a/src/components/livekit/agent-control-bar.tsx
+++ b/src/components/livekit/agent-control-bar.tsx
@@ -28,7 +28,7 @@ export function AgentControlBar({ className, onDisconnect, onRequestEnd, onSendM
   return (
     <div className={`flex flex-col rounded-[31px]  ${className ?? ''}`} {...props}>
       <div className='flex flex-row justify-end gap-1'>
-        <Button variant='default' onClick={onLeave} className='font-mono'>结束面试</Button>
+        <Button variant='default' onClick={onLeave} className='font-mono'>放弃面试</Button>
       </div>
     </div>
   )

--- a/src/features/interview/index.tsx
+++ b/src/features/interview/index.tsx
@@ -392,15 +392,15 @@ export default function InterviewPage({ interviewId, jobId, jobApplyId, intervie
       <Dialog open={confirmEndOpen} onOpenChange={setConfirmEndOpen}>
         <DialogContent className='sm:max-w-md'>
           <DialogHeader className='text-left'>
-            <DialogTitle>确认要提前结束面试吗？</DialogTitle>
-            <DialogDescription>提前结束面试将影响您的面试结果评估</DialogDescription>
+            <DialogTitle>确认要放弃面试吗？</DialogTitle>
+            <DialogDescription>放弃面试将没有面试结果，若需要请重新面试</DialogDescription>
           </DialogHeader>
           <DialogFooter className='gap-2'>
             <Button onClick={() => setConfirmEndOpen(false)}>继续面试</Button>
             <Button variant='outline' onClick={() => {
               setConfirmEndOpen(false)
               performEndInterview()
-            }}>确定结束</Button>
+            }}>确定放弃</Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>


### PR DESCRIPTION
- 将"结束面试"按钮文案改为"放弃面试"
- 更新确认对话框标题和描述，明确放弃面试的后果
- 调整确认按钮文案为"确定放弃"

## 描述

<!-- 请清晰、简洁地描述此 PR 的变更内容，并说明相关的动机与背景。 -->

## 变更类型

<!-- 你的代码为本项目引入了哪些类型的变更？在适用的选项中用 `x` 标注 -->

- [ ] Bug 修复（非破坏性更改，用于修复问题）
- [ ] 新功能（非破坏性更改，增加新功能）
- [ ] 其他（未在以上列出的更改）

## 清单

<!-- 提交 PR 前请遵循以下清单，并在完成项目前加上 [x]。也可以在创建 PR 后补充。此清单用于帮助我们在合并前进行检查。 -->

- [ ] 我已阅读 [贡献指南](https://github.com/satnaing/shadcn-admin/blob/main/.github/CONTRIBUTING.md)

## 进一步说明

<!-- 如果这是较大或复杂的变更，请解释你为何选择该方案，以及你考虑过的替代方案等。 -->

## 关联的 Issue

<!-- 如果此 PR 与现有 Issue 相关，请在此处进行链接。 -->

关闭：#<!-- 相关 Issue 编号（如适用） -->