### PR TITLE
为背景颜色类添加 30% 不透明度的样式，支持普通模式和暗黑模式的兼容性。

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -297,6 +297,10 @@
   background-color: rgba(78, 2, 228, 0.2); /* Fallback using --color-blue-600 */
 }
 
+.bg-primary\/30 {
+  background-color: rgba(78, 2, 228, 0.3); /* Fallback using --color-blue-600 */
+}
+
 .border-border {
   border-color: #e2e8f0; /* Fallback */
 }
@@ -313,6 +317,10 @@
   background-color: rgba(226, 232, 240, 0.2); /* Dark mode fallback */
 }
 
+.dark .bg-primary\/30 {
+  background-color: rgba(226, 232, 240, 0.3); /* Dark mode fallback */
+}
+
 .dark .border-border {
   border-color: rgba(255, 255, 255, 0.1); /* Dark mode fallback */
 }
@@ -325,6 +333,10 @@
   
   .bg-primary\/20 {
     background-color: oklch(0.208 0.042 265.755 / 0.2); /* Primary color with 20% opacity */
+  }
+  
+  .bg-primary\/30 {
+    background-color: oklch(0.208 0.042 265.755 / 0.3); /* Primary color with 30% opacity */
   }
   
   .border-border {
@@ -342,5 +354,9 @@
   
   .dark .bg-primary\/20 {
     background-color: oklch(0.929 0.013 255.508 / 0.2); /* Dark mode primary with 20% opacity */
+  }
+  
+  .dark .bg-primary\/30 {
+    background-color: oklch(0.929 0.013 255.508 / 0.3); /* Dark mode primary with 30% opacity */
   }
 }


### PR DESCRIPTION
## 描述

<!-- 请清晰、简洁地描述此 PR 的变更内容，并说明相关的动机与背景。 -->

## 变更类型

<!-- 你的代码为本项目引入了哪些类型的变更？在适用的选项中用 `x` 标注 -->

- [ ] Bug 修复（非破坏性更改，用于修复问题）
- [ ] 新功能（非破坏性更改，增加新功能）
- [ ] 其他（未在以上列出的更改）

## 清单

<!-- 提交 PR 前请遵循以下清单，并在完成项目前加上 [x]。也可以在创建 PR 后补充。此清单用于帮助我们在合并前进行检查。 -->

- [ ] 我已阅读 [贡献指南](https://github.com/satnaing/shadcn-admin/blob/main/.github/CONTRIBUTING.md)

## 进一步说明

<!-- 如果这是较大或复杂的变更，请解释你为何选择该方案，以及你考虑过的替代方案等。 -->

## 关联的 Issue

<!-- 如果此 PR 与现有 Issue 相关，请在此处进行链接。 -->

关闭：#<!-- 相关 Issue 编号（如适用） -->