### PR TITLE
fix(interview): 优化用户离开时的处理逻辑移除 endedOnceRef 的重复执行判断，确保每次用户离开时都能正确执行资源…

### DIFF
--- a/src/features/interview/session-view-page/lib/listenerHooks.ts
+++ b/src/features/interview/session-view-page/lib/listenerHooks.ts
@@ -55,20 +55,18 @@ const useRtcListeners = (): IEventListener => {
     // no-op for now; can add toast/report here
   };
 
-  const endedOnceRef = useRef(false)
   const handleUserLeave = async (e: onUserLeaveEvent) => {
     const { userId } = e.userInfo;
     roomStore.remoteUserLeave({ userId: e.userInfo.userId });
     roomStore.removeAutoPlayFail({ userId: e.userInfo.userId });
 
-    if (endedOnceRef.current) return
-    endedOnceRef.current = true
     try { await RtcClient.stopAudioCapture() } catch { /* noop */ }
     try { await RtcClient.stopVideoCapture() } catch { /* noop */ }
     try { await RtcClient.leaveRoom() } catch { /* noop */ }
 
     try {
       console.log('>>> handleUserLeave', e.userInfo)
+      debugger
       // 如果不是Agent离开，则不触发后续流程
       if (/ChatBot/.test(userId)) {
         const params = new URLSearchParams(window.location.search)
@@ -94,7 +92,7 @@ const useRtcListeners = (): IEventListener => {
         }
         // 跳转 finish（使用原生 replace 便于释放设备权限）
         setTimeout(() => {
-          window.location.replace(`/finish?${params.toString()}`)
+          // window.location.replace(`/finish?${params.toString()}`)
         }, 300)
       }
     } catch { /* ignore */ }


### PR DESCRIPTION
…释放逻辑。

注释掉页面跳转逻辑，便于调试时保留当前页面状态。
添加 debugger语句，方便调试用户离开时的数据状态。

## 描述

<!-- 请清晰、简洁地描述此 PR 的变更内容，并说明相关的动机与背景。 -->

## 变更类型

<!-- 你的代码为本项目引入了哪些类型的变更？在适用的选项中用 `x` 标注 -->

- [ ] Bug 修复（非破坏性更改，用于修复问题）
- [ ] 新功能（非破坏性更改，增加新功能）
- [ ] 其他（未在以上列出的更改）

## 清单

<!-- 提交 PR 前请遵循以下清单，并在完成项目前加上 [x]。也可以在创建 PR 后补充。此清单用于帮助我们在合并前进行检查。 -->

- [ ] 我已阅读 [贡献指南](https://github.com/satnaing/shadcn-admin/blob/main/.github/CONTRIBUTING.md)

## 进一步说明

<!-- 如果这是较大或复杂的变更，请解释你为何选择该方案，以及你考虑过的替代方案等。 -->

## 关联的 Issue

<!-- 如果此 PR 与现有 Issue 相关，请在此处进行链接。 -->

关闭：#<!-- 相关 Issue 编号（如适用） -->