### PR TITLE
feat(interview): 优化候选人离线逻辑并新增房间状态管理- 在 roomStore 中新增 isCandidateInRoo…

### DIFF
--- a/src/features/interview/session-view-page/lib/listenerHooks.ts
+++ b/src/features/interview/session-view-page/lib/listenerHooks.ts
@@ -65,10 +65,9 @@ const useRtcListeners = (): IEventListener => {
     try { await RtcClient.leaveRoom() } catch { /* noop */ }
 
     try {
-      console.log('>>> handleUserLeave', e.userInfo)
-      debugger
-      // 如果不是Agent离开，则不触发后续流程
-      if (/ChatBot/.test(userId)) {
+      const isCandidateInRoom = roomStore.getCandidateInRoom()
+      // 如果候选人在房间里，并且此时离开的是Agent。那么代表Agent是主动离开的，而不是由于候选人离开而离开的。
+      if (isCandidateInRoom && /ChatBot/.test(userId)) {
         const params = new URLSearchParams(window.location.search)
         const interviewId = roomStore.rtcConnectionInfo?.interview_id
         if (interviewId != null) params.set('interview_id', String(interviewId))
@@ -78,7 +77,7 @@ const useRtcListeners = (): IEventListener => {
         const jobApplyId = params.get('job_apply_id')
         if (jobApplyId) params.set('job_apply_id', jobApplyId)
         const interviewNodeId = params.get('interview_node_id')
-  
+
         // 上报并提交节点
         userEvent('interview_completed', '面试正常结束', {
           job_id: jobId ?? undefined,

--- a/src/features/interview/session-view-page/lib/useCommon.ts
+++ b/src/features/interview/session-view-page/lib/useCommon.ts
@@ -77,7 +77,7 @@ export const useDeviceState = () => {
     }
     // queryDevices(MediaType.VIDEO);
     await (!isVideoPublished ? RtcClient.startVideoCapture() : RtcClient.stopVideoCapture());
-    
+
     // RtcClient.publishStream(MediaType.AUDIO_AND_VIDEO)
     roomActions.updateLocalUser({ publishVideo: !isVideoPublished })
   };
@@ -162,7 +162,9 @@ export const useJoin = (): [boolean, () => Promise<void | boolean>] => {
     }
 
     setJoining(true);
-    console.log('>>> rtcInfo', rtcInfo)
+
+    // 标记候选人进入房间
+    useRoomStore.getState().setCandidateInRoom(true)
     // 0. 准备 RTC 基础信息（来自 roomStore.rtcConnectionInfo）
     if (!rtcInfo?.room_id || !rtcInfo?.user_id || !rtcInfo?.token) {
       toast.error('缺少会话连接信息，请返回上一步重试。', { position: 'top-center' })
@@ -228,6 +230,8 @@ export const useLeave = () => {
     ]);
     await RtcClient.stopAgent(roomId ?? '');
     await RtcClient.leaveRoom();
+    // 标记候选人离开房间
+    useRoomStore.getState().setCandidateInRoom(false)
     const room = useRoomStore.getState()
     room.clearHistoryMsg()
     room.clearCurrentMsg()

--- a/src/stores/interview/room.ts
+++ b/src/stores/interview/room.ts
@@ -86,6 +86,12 @@ export interface RoomState {
    * @brief AI 通话是否启用
    */
   isAIGCEnable: boolean;
+
+
+  /**
+   * @brief 候选人是否在房间
+   */
+  isCandidateInRoom: boolean;
   /**
    * @brief AI 是否正在说话
    */
@@ -164,6 +170,8 @@ const initialState: RoomState = {
   isUserTalking: false,
   networkQuality: NetworkQuality.UNKNOWN,
 
+  isCandidateInRoom: false,
+
   msgHistory: [],
   currentConversation: {},
   isShowSubtitle: true,
@@ -198,9 +206,11 @@ export interface RoomActions {
   updateFullScreen: (payload: { isFullScreen: boolean }) => void;
   updatecustomSceneName: (payload: { customSceneName: string }) => void;
   setRtcConnectionInfo: (payload?: RtcConnectionInfo) => void;
+  setCandidateInRoom: (inRoom: boolean) => void;
+  getCandidateInRoom: () => boolean;
 }
 
-export const useRoomStore = create<RoomState & RoomActions>()((set) => ({
+export const useRoomStore = create<RoomState & RoomActions>()((set, get) => ({
   ...initialState,
   localJoinRoom: ({ roomId, user }) =>
     set((state) => ({ ...state, roomId, localUser: { ...state.localUser, ...user }, isJoined: true })),
@@ -295,6 +305,8 @@ export const useRoomStore = create<RoomState & RoomActions>()((set) => ({
   updateFullScreen: ({ isFullScreen }) => set((state) => ({ ...state, isFullScreen })),
   updatecustomSceneName: ({ customSceneName }) => set((state) => ({ ...state, customSceneName })),
   setRtcConnectionInfo: (payload) => set((state) => ({ ...state, rtcConnectionInfo: payload })),
+  setCandidateInRoom: (inRoom: boolean) => set((state) => ({ ...state, isCandidateInRoom: inRoom })),
+  getCandidateInRoom: () => get().isCandidateInRoom,
 }))
 
 export default useRoomStore;


### PR DESCRIPTION
…m 状态，用于标记候选人是否在房间内

- 新增 setCandidateInRoom 和 getCandidateInRoom 方法用于更新和获取候选人房间状态- 在候选人加入房间时设置 isCandidateInRoom为 true，离开时设为 false
- 调整 handleUserLeave 判断逻辑，只有当候选人不在房间且 Agent 离开时才触发面试结束流程
- 移除调试代码 console.log 和 debugger -修正部分格式问题（如空行）

## 描述

<!-- 请清晰、简洁地描述此 PR 的变更内容，并说明相关的动机与背景。 -->

## 变更类型

<!-- 你的代码为本项目引入了哪些类型的变更？在适用的选项中用 `x` 标注 -->

- [ ] Bug 修复（非破坏性更改，用于修复问题）
- [ ] 新功能（非破坏性更改，增加新功能）
- [ ] 其他（未在以上列出的更改）

## 清单

<!-- 提交 PR 前请遵循以下清单，并在完成项目前加上 [x]。也可以在创建 PR 后补充。此清单用于帮助我们在合并前进行检查。 -->

- [ ] 我已阅读 [贡献指南](https://github.com/satnaing/shadcn-admin/blob/main/.github/CONTRIBUTING.md)

## 进一步说明

<!-- 如果这是较大或复杂的变更，请解释你为何选择该方案，以及你考虑过的替代方案等。 -->

## 关联的 Issue

<!-- 如果此 PR 与现有 Issue 相关，请在此处进行链接。 -->

关闭：#<!-- 相关 Issue 编号（如适用） -->