### PR TITLE
feat(interview): 优化面试间连接信息加载逻辑将 RTC 连接信息的加载时机从页面初始化调整为点击加入房间时加载，

### DIFF
--- a/src/features/interview/prepare.tsx
+++ b/src/features/interview/prepare.tsx
@@ -285,7 +285,6 @@ export default function InterviewPreparePage({ jobId, inviteToken, isSkipConfirm
   const cam = useMediaDeviceSelect({ kind: 'videoinput', requestPermissions: viewMode === ViewMode.InterviewPrepare })
   const [_joining, triggerJoin] = useJoin()
   const setRtcConnectionInfo = useRoomStore((s) => s.setRtcConnectionInfo)
-  const rtcInfo = useRoomStore((s) => s.rtcConnectionInfo)
   // 当视频设备自动选择时，保存为默认选择
   useEffect(() => {
     const preferred = getPreferredDeviceId('videoinput')
@@ -439,48 +438,40 @@ export default function InterviewPreparePage({ jobId, inviteToken, isSkipConfirm
     }
   }, [jobId, interviewNodeId, connecting, navigate, jobApplyId])
 
-  // 获取RTC的连接信息并更新至local Storage中
-  const loadRtcConnectionInfo = useCallback(async () => {
-    try {
-      const params = new URLSearchParams(window.location.search)
-      // FIXME 暂时用4做兜底
-      const jobIdStr = params.get('job_id') || "2"
-      const jobId = jobIdStr ? Number(jobIdStr) : NaN
-      if (!jobIdStr || Number.isNaN(jobId)) {
-        toast.error('缺少或无效的 job_id 参数', { position: 'top-center' })
-        return
-      }
-      const info = await getRtcConnectionInfo({ job_id: jobId })
-      setRtcConnectionInfo(info)
-      // 更新至local Storage中
-      localStorage.setItem(`rtc_connection_info:v1:${info.interview_id}`, JSON.stringify(info))
+  // 旧逻辑：页面初始化即加载 RTC 连接信息（已废弃，改为点击时加载）
 
-    } catch (_e) {
-      toast.error('获取面试连接信息失败，请稍后重试', { position: 'top-center' })
-    }
-  }, [setRtcConnectionInfo])
-
-  useEffect(() => {
-    // 每次页面初始化后
-    void loadRtcConnectionInfo();
-  }, [loadRtcConnectionInfo])
+  // 需求调整：不在初始化时加载 RTC 连接信息，改为点击时再加载
   /**
    * - session-view-page: interview_id=2181&job_id=2&job_apply_id=169&interview_node_id=795
    * - finish: ?interview_id=2181&job_id=2&job_apply_id=169&interview_node_id=795
   */
   // 新版面试间
-  const onStartNewInterviewClick = async() => {
-    await triggerJoin()
-    navigate({
-      to: '/interview/session_view',
-      search: {
-        interview_id: rtcInfo?.interview_id,
-        job_id: jobId ?? undefined,
-        job_apply_id: jobApplyId ?? undefined,
-        interview_node_id: interviewNodeId ?? undefined,
-        room_id: rtcInfo?.room_id,
-      } as unknown as Record<string, unknown>,
-    })
+  const onStartNewInterviewClick = async () => {
+    if (!jobId || !interviewNodeId || connecting) return
+    setConnecting(true)
+    try {
+      // 1) 点击时实时获取最新的 RTC 连接信息
+      const info = await getRtcConnectionInfo({ job_id: Number(jobId ?? 0) })
+      // 2) 写入全局 store，并持久化到 localStorage，避免依赖异步 state 读取旧值
+      setRtcConnectionInfo(info)
+      localStorage.setItem(`rtc_connection_info:v1:${info.interview_id}`, JSON.stringify(info))
+      // 3) 加入房间
+      await triggerJoin()
+      // 4) 使用刚拿到的 info 进行跳转，避免读取尚未更新的 store
+      navigate({
+        to: '/interview/session_view',
+        search: {
+          interview_id: info.interview_id,
+          job_id: jobId ?? undefined,
+          job_apply_id: jobApplyId ?? undefined,
+          interview_node_id: interviewNodeId ?? undefined,
+          room_id: info.room_id,
+        } as unknown as Record<string, unknown>,
+      })
+    } catch (_e) {
+      toast.error('获取面试连接信息失败，请稍后重试', { position: 'top-center' })
+      setConnecting(false)
+    }
   }
 
   function nodeNameToViewMode(name: string): ViewMode {

--- a/src/features/interview/session-view-page/index.tsx
+++ b/src/features/interview/session-view-page/index.tsx
@@ -52,28 +52,28 @@ export default function InterviewSessionViewPage() {
       console.log('use effect >>> leave room')
       leaveRoom()
     }
-  }, [leaveRoom])
+  }, [])
 
   // 判断是否为刷新的逻辑
-    // 进入页面后再次尝试从存储读取（防止刷新后初始状态为 null）
-    const hasLoadedDetailsRef = useRef(false)
-    useEffect(() => {
-      // 防止严格模式下重复执行
-      if (hasLoadedDetailsRef.current) return
-      const interviewId = new URLSearchParams(window.location.search).get('interview_id')
-      const jobId = new URLSearchParams(window.location.search).get('job_id')
-      const jobApplyId = new URLSearchParams(window.location.search).get('job_apply_id')
-      const details = localStorage.getItem(`rtc_connection_info:v1:${interviewId}`)
+  // 进入页面后再次尝试从存储读取（防止刷新后初始状态为 null）
+  const hasLoadedDetailsRef = useRef(false)
+  useEffect(() => {
+    // 防止严格模式下重复执行
+    if (hasLoadedDetailsRef.current) return
+    const interviewId = new URLSearchParams(window.location.search).get('interview_id')
+    const jobId = new URLSearchParams(window.location.search).get('job_id')
+    const jobApplyId = new URLSearchParams(window.location.search).get('job_apply_id')
+    const details = localStorage.getItem(`rtc_connection_info:v1:${interviewId}`)
 
-      if (details) {
-        hasLoadedDetailsRef.current = true
-        localStorage.removeItem(`rtc_connection_info:v1:${interviewId}`)
-      } else {
-        let url = `/interview/prepare?data=job_id${jobId}andisSkipConfirmtrue&source=session_refresh`
-        if (jobApplyId) url += `&job_apply_id=${jobApplyId}`
-        navigate({ to: url, replace: true })
-      }
-    }, [])
+    if (details) {
+      hasLoadedDetailsRef.current = true
+      localStorage.removeItem(`rtc_connection_info:v1:${interviewId}`)
+    } else {
+      let url = `/interview/prepare?data=job_id${jobId}andisSkipConfirmtrue&source=session_refresh`
+      if (jobApplyId) url += `&job_apply_id=${jobApplyId}`
+      navigate({ to: url, replace: true })
+    }
+  }, [])
 
 
   return (
@@ -138,5 +138,4 @@ export default function InterviewSessionViewPage() {
     </>
   )
 }
-
 

--- a/src/features/interview/session-view-page/lib/useCommon.ts
+++ b/src/features/interview/session-view-page/lib/useCommon.ts
@@ -136,7 +136,6 @@ export const useGetDevicePermission = () => {
 export const useJoin = (): [boolean, () => Promise<void | boolean>] => {
   const devicePermissions = useDeviceStore((s) => s.devicePermissions)
   const room = useRoomStore()
-  const rtcInfo = useRoomStore((s) => s.rtcConnectionInfo)
 
   const { id } = useScene();
   const { switchMic } = useDeviceState();
@@ -169,7 +168,8 @@ export const useJoin = (): [boolean, () => Promise<void | boolean>] => {
 
     // 标记候选人进入房间
     useRoomStore.getState().setCandidateInRoom(true)
-    // 0. 准备 RTC 基础信息（来自 roomStore.rtcConnectionInfo）
+    // 0. 准备 RTC 基础信息（执行时读取最新 store，避免闭包读取旧值）
+    const rtcInfo = useRoomStore.getState().rtcConnectionInfo
     if (!rtcInfo?.room_id || !rtcInfo?.user_id || !rtcInfo?.token) {
       toast.error('缺少会话连接信息，请返回上一步重试。', { position: 'top-center' })
       setJoining(false)


### PR DESCRIPTION
避免因异步状态导致的信息不一致问题。同时移除了 useEffect 中对
leaveRoom 的依赖数组冗余项，并修复 prepare 页面中未使用的变量。

此外，useJoin hook 中改为实时读取最新 store 数据，确保获取正确的
RTC 连接信息。

## 描述

<!-- 请清晰、简洁地描述此 PR 的变更内容，并说明相关的动机与背景。 -->

## 变更类型

<!-- 你的代码为本项目引入了哪些类型的变更？在适用的选项中用 `x` 标注 -->

- [ ] Bug 修复（非破坏性更改，用于修复问题）
- [ ] 新功能（非破坏性更改，增加新功能）
- [ ] 其他（未在以上列出的更改）

## 清单

<!-- 提交 PR 前请遵循以下清单，并在完成项目前加上 [x]。也可以在创建 PR 后补充。此清单用于帮助我们在合并前进行检查。 -->

- [ ] 我已阅读 [贡献指南](https://github.com/satnaing/shadcn-admin/blob/main/.github/CONTRIBUTING.md)

## 进一步说明

<!-- 如果这是较大或复杂的变更，请解释你为何选择该方案，以及你考虑过的替代方案等。 -->

## 关联的 Issue

<!-- 如果此 PR 与现有 Issue 相关，请在此处进行链接。 -->

关闭：#<!-- 相关 Issue 编号（如适用） -->