### PR TITLE
fix(interview):修复面试结束后跳转链接缺少 interview_id 参数的问题

### DIFF
--- a/src/features/interview/session-view-page/index.tsx
+++ b/src/features/interview/session-view-page/index.tsx
@@ -35,11 +35,19 @@ export default function InterviewSessionViewPage() {
         interview_id: interviewId,
         job_apply_id: jobApplyId,
       })
+      if (storeInterviewId != null) params.set('interview_id', String(storeInterviewId))
     } catch { /* ignore */ }
 
     await leaveRoom()
     setTimeout(() => {
-      window.location.replace('/finish')
+      try {
+        const params = new URLSearchParams(window.location.search)
+        const storeInterviewId = useRoomStore.getState().rtcConnectionInfo?.interview_id
+        if (storeInterviewId != null) params.set('interview_id', String(storeInterviewId))
+        window.location.replace(`/finish?${params.toString()}`)
+      } catch {
+        window.location.replace('/finish')
+      }
     }, 1000)
   }, [leaveRoom])
 


### PR DESCRIPTION
在面试结束后的页面跳转中，确保将 interview_id 参数正确附加到 URL 上，
以便后续页面能够正确识别面试会话。同时添加了错误处理机制，防止参数处理过程中出现异常导致跳转失败。

## 描述

<!-- 请清晰、简洁地描述此 PR 的变更内容，并说明相关的动机与背景。 -->

## 变更类型

<!-- 你的代码为本项目引入了哪些类型的变更？在适用的选项中用 `x` 标注 -->

- [ ] Bug 修复（非破坏性更改，用于修复问题）
- [ ] 新功能（非破坏性更改，增加新功能）
- [ ] 其他（未在以上列出的更改）

## 清单

<!-- 提交 PR 前请遵循以下清单，并在完成项目前加上 [x]。也可以在创建 PR 后补充。此清单用于帮助我们在合并前进行检查。 -->

- [ ] 我已阅读 [贡献指南](https://github.com/satnaing/shadcn-admin/blob/main/.github/CONTRIBUTING.md)

## 进一步说明

<!-- 如果这是较大或复杂的变更，请解释你为何选择该方案，以及你考虑过的替代方案等。 -->

## 关联的 Issue

<!-- 如果此 PR 与现有 Issue 相关，请在此处进行链接。 -->

关闭：#<!-- 相关 Issue 编号（如适用） -->