### PR TITLE
feat(apm): 新增低分反馈事件上报功能

### DIFF
--- a/src/lib/apm.ts
+++ b/src/lib/apm.ts
@@ -343,3 +343,47 @@ export function reportSessionPageRefresh(extra?: Record<string, string>): void {
     type: 'event',
   })
 }
+
+// Finish 页面：当用户评分 <= 4 星时，上报一次低分反馈事件
+export interface FinishFeedbackLowScorePayload {
+  interview_id: number
+  total_score: number
+  flow_score?: number
+  expression_score?: number
+  relevance_score?: number
+  feedback_text?: string
+  job_id?: string | number
+  job_apply_id?: string | number
+}
+
+export function reportFinishFeedbackLowScore(payload: FinishFeedbackLowScorePayload): void {
+  if (!apmClient) return
+  const {
+    interview_id,
+    total_score,
+    flow_score,
+    expression_score,
+    relevance_score,
+    feedback_text,
+    job_id,
+    job_apply_id,
+  } = payload
+  const categories: Record<string, string> = {
+    page: 'finish',
+    interview_id: String(interview_id),
+    total_score: String(total_score),
+  }
+  if (typeof flow_score !== 'undefined') categories.flow_score = String(flow_score)
+  if (typeof expression_score !== 'undefined') categories.expression_score = String(expression_score)
+  if (typeof relevance_score !== 'undefined') categories.relevance_score = String(relevance_score)
+  if (typeof feedback_text !== 'undefined') categories.feedback_text = stringifyForCategory(feedback_text)
+  if (typeof job_id !== 'undefined') categories.job_id = String(job_id)
+  if (typeof job_apply_id !== 'undefined') categories.job_apply_id = String(job_apply_id)
+
+  apmClient('sendEvent', {
+    name: 'finish_feedback_low_score',
+    categories,
+    metrics: {},
+    type: 'event',
+  })
+}


### PR DESCRIPTION
在面试结束页面中，当用户评分小于等于4星时，新增上报一次自定义 APM事件，
用于收集用户对面试体验的细分反馈数据。包括流畅度、表达理解、问题相关性等维度评分及文本反馈。同时新增对应的类型定义和上报函数，并在页面中展示 相应的评分控件以收集详细评分信息。

## 描述

<!-- 请清晰、简洁地描述此 PR 的变更内容，并说明相关的动机与背景。 -->

## 变更类型

<!-- 你的代码为本项目引入了哪些类型的变更？在适用的选项中用 `x` 标注 -->

- [ ] Bug 修复（非破坏性更改，用于修复问题）
- [ ] 新功能（非破坏性更改，增加新功能）
- [ ] 其他（未在以上列出的更改）

## 清单

<!-- 提交 PR 前请遵循以下清单，并在完成项目前加上 [x]。也可以在创建 PR 后补充。此清单用于帮助我们在合并前进行检查。 -->

- [ ] 我已阅读 [贡献指南](https://github.com/satnaing/shadcn-admin/blob/main/.github/CONTRIBUTING.md)

## 进一步说明

<!-- 如果这是较大或复杂的变更，请解释你为何选择该方案，以及你考虑过的替代方案等。 -->

## 关联的 Issue

<!-- 如果此 PR 与现有 Issue 相关，请在此处进行链接。 -->

关闭：#<!-- 相关 Issue 编号（如适用） -->