### PR TITLE
feat(finish): 优化低分评价逻辑并调整支持弹窗触发方式

### DIFF
--- a/src/features/finish/index.tsx
+++ b/src/features/finish/index.tsx
@@ -132,6 +132,8 @@ export default function FinishPage() {
 
   const goNext = async () => {
     if (!interviewId || rating <= 0 || submitting) return
+    // 低分时强制要求细分评分全部选择
+    if (rating <= 4 && (flowScore <= 0 || expressionScore <= 0 || relevanceScore <= 0)) return
     // 当评分 <= 4 星时，额外上报自定义 APM 事件（不影响原有接口上报）
     if (rating <= 4) {
       try {
@@ -162,37 +164,17 @@ export default function FinishPage() {
     })
   }
 
-  const handleHelp = () => {
-    setHelpOpen(true)
-  }
-
-  //  暂时展出提交资料符合页面
-  // if (finishSubmit) {
-  //   return (
-  //     <Main
-  //       fixed
-  //       className={`flex w-full items-center justify-center bg-white`}
-  //     >
-  //       <img
-  //         src={
-  //           'https://dnu-cdn.xpertiise.com/common/8af6d9a9-6f39-47e2-ac48-74abe3c833e6.svg'
-  //         }
-  //         alt='meetchances'
-  //         className='mb-[32px] ml-3 h-[120px] w-[140px] object-contain'
-  //       />
-  //       <h2 className='mb-3 text-xl font-semibold'>复核面试中</h2>
-  //       <p className='mb-6 max-w-[428px] text-center text-sm opacity-70'>
-  //         感谢您完成面试，我们正在复核您的面试过程，预计48小时内通知您，请等待短信通知
-  //       </p>
-  //     </Main>
-  //   )
-  // }
+  // 保留：如需在其它位置触发支持弹窗，可调用 setHelpOpen(true)
 
   return (
     <Main
       fixed
       className={`flex w-full items-center justify-center bg-[#ECD9FC]`}
     >
+      {/* 右上角：寻求支持 */}
+      <div className='absolute right-6 top-6'>
+        <Button variant='link' className='text-primary' onClick={() => setHelpOpen(true)}>寻求支持</Button>
+      </div>
       <section className='min-w-[418px] space-y-6'>
         <Card>
           <CardContent className='p-6'>
@@ -220,7 +202,7 @@ export default function FinishPage() {
               })}
             </div>
 
-           
+
             {rating > 0 && rating <= 4 && (
               <div className='mt-6 space-y-6'>
                 <div>
@@ -290,7 +272,7 @@ export default function FinishPage() {
                       )
                     })}
                   </div>
-                
+
                   {rating > 0 && (
                     <div className='space-y-2 text-center mt-4'>
                       <Textarea
@@ -320,7 +302,9 @@ export default function FinishPage() {
         <div className='flex items-center justify-center'>
           <Button
             onClick={goNext}
-            disabled={rating <= 0 || submitting}
+            disabled={
+              rating <= 0 || submitting || (rating <= 4 && (flowScore <= 0 || expressionScore <= 0 || relevanceScore <= 0))
+            }
             className='h-[44px] w-[200px] bg-[linear-gradient(90deg,#4E02E4_10%,#C994F7_100%)] text-white'
           >
             提交
@@ -355,15 +339,6 @@ export default function FinishPage() {
           </div>
         </section>
       )} */}
-      <div className='absolute right-0 bottom-3 left-0 text-center text-sm text-black/70'>
-        需要支持请
-        <span
-          className='cursor-pointer text-[var(--color-blue-600)] underline'
-          onClick={handleHelp}
-        >
-          寻求帮助
-        </span>
-      </div>
 
       {/* 寻求支持弹窗 */}
       <SupportDialog


### PR DESCRIPTION
当用户评分低于或等于 4 星时，强制要求完成所有细分评分（流程、表达、相关性）才能提交。
同时，将“寻求支持”按钮移至页面右上角，并移除原有的底部支持提示文案。
此外，更新了提交按钮的禁用条件以匹配新的评分验证逻辑。

## 描述

<!-- 请清晰、简洁地描述此 PR 的变更内容，并说明相关的动机与背景。 -->

## 变更类型

<!-- 你的代码为本项目引入了哪些类型的变更？在适用的选项中用 `x` 标注 -->

- [ ] Bug 修复（非破坏性更改，用于修复问题）
- [ ] 新功能（非破坏性更改，增加新功能）
- [ ] 其他（未在以上列出的更改）

## 清单

<!-- 提交 PR 前请遵循以下清单，并在完成项目前加上 [x]。也可以在创建 PR 后补充。此清单用于帮助我们在合并前进行检查。 -->

- [ ] 我已阅读 [贡献指南](https://github.com/satnaing/shadcn-admin/blob/main/.github/CONTRIBUTING.md)

## 进一步说明

<!-- 如果这是较大或复杂的变更，请解释你为何选择该方案，以及你考虑过的替代方案等。 -->

## 关联的 Issue

<!-- 如果此 PR 与现有 Issue 相关，请在此处进行链接。 -->

关闭：#<!-- 相关 Issue 编号（如适用） -->