### PR TITLE
feat(jobs): 支持从 URL 参数自动展开岗位详情抽屉新增从 URL 查询参数 `job_id` 中读取初始选中岗位 ID，并在…

### DIFF
--- a/src/features/jobs/index.tsx
+++ b/src/features/jobs/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useEffect } from 'react'
 import { IconClockHour4, IconCurrencyYen } from '@tabler/icons-react'
 import { cn } from '@/lib/utils'
 // import { Search } from '@/components/search'
@@ -15,6 +15,7 @@ import { Main } from '@/components/layout/main'
 // import { TopNav } from '@/components/layout/top-nav'
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { userEvent } from '@/lib/apm'
+import { useNavigate, useRouterState } from '@tanstack/react-router'
 
 // import { ExploreJobs } from './mockData.ts'
 import {
@@ -46,10 +47,23 @@ function formatPublishTime(createdAt?: string): string {
 }
 
 export default function JobsListPage() {
-  // const navigate = useNavigate()
+  const navigate = useNavigate()
+  const { location } = useRouterState()
+  const search = location.search as Record<string, unknown>
+
+  const jobIdFromUrl = useMemo(() => {
+    const v = search?.job_id
+    if (typeof v === 'string') {
+      const n = Number(v)
+      return Number.isNaN(n) ? v : n
+    }
+    if (typeof v === 'number') return v
+    return null
+  }, [search])
 
   const [selectedJob, setSelectedJob] = useState<ApiJob | null>(null)
-  const [isDrawerOpen, setIsDrawerOpen] = useState(false)
+  const [selectedJobId, setSelectedJobId] = useState<string | number | null>(jobIdFromUrl)
+  const [isDrawerOpen, setIsDrawerOpen] = useState<boolean>(Boolean(jobIdFromUrl))
 
   const [sortBy, setSortBy] = useState<JobsSortBy>(JobsSortBy.PublishTime)
   const [sortOrder, setSortOrder] = useState<JobsSortOrder>(JobsSortOrder.Desc)
@@ -65,23 +79,54 @@ export default function JobsListPage() {
   const { data: applyStatusMap } = useJobApplyStatus(jobIds, Boolean(jobIds.length))
 
   // 当只拿到列表的精简数据时，点击后再拉详情
-  const { data: detailData } = useJobDetailQuery(
-    selectedJob?.id ?? null,
-    isDrawerOpen
-  )
+  const effectiveSelectedId = selectedJobId ?? selectedJob?.id ?? null
+  const { data: detailData } = useJobDetailQuery(effectiveSelectedId, isDrawerOpen)
   const selectedJobData = detailData ?? selectedJob
 
   const handleSelectJob = (job: ApiJob) => {
     setSelectedJob(job)
+    setSelectedJobId(job.id)
     setIsDrawerOpen(true)
     userEvent('position_item_clicked', '点击岗位列表项', { job_id: job.id })
+    navigate({
+      to: location.pathname,
+      search: (prev) => ({ ...(prev as Record<string, unknown>), job_id: job.id }),
+    })
   }
 
   const handleCloseDrawer = () => {
     setIsDrawerOpen(false)
-    // 关闭后清理当前选中数据
     setSelectedJob(null)
+    setSelectedJobId(null)
+    // 从 URL 移除 job_id
+    navigate({
+      to: location.pathname,
+      search: (prev) => {
+        const { job_id: _omit, ...rest } = (prev || {}) as Record<string, unknown>
+        return rest
+      },
+    })
   }
+
+  // 当 URL 中存在 job_id 时，进入页面后自动展开并同步本地状态
+  useEffect(() => {
+    if (jobIdFromUrl) {
+      setIsDrawerOpen(true)
+      setSelectedJobId(jobIdFromUrl)
+    } else {
+      setIsDrawerOpen(false)
+      setSelectedJobId(null)
+      setSelectedJob(null)
+    }
+  }, [jobIdFromUrl])
+
+  // 当列表加载后，如果 URL 有 job_id 但本地还没选中具体 Job，则尝试从列表中填充
+  useEffect(() => {
+    if (jobIdFromUrl && !selectedJob) {
+      const found = jobs.find((j) => String(j.id) === String(jobIdFromUrl))
+      if (found) setSelectedJob(found)
+    }
+  }, [jobIdFromUrl, jobs, selectedJob])
 
   const isPublishActive = sortBy === JobsSortBy.PublishTime
   const isSalaryActive = sortBy === JobsSortBy.SalaryMax
@@ -182,7 +227,7 @@ export default function JobsListPage() {
                       </li>
                     ))
                   : [...jobs].map((job: ApiJob) => {
-                      const isActive = selectedJob?.id === job.id
+                      const isActive = String(selectedJobId ?? selectedJob?.id ?? '') === String(job.id)
                       return (
                         <li key={job.id}>
                           <div


### PR DESCRIPTION
…页面加载时自动展开对应的岗位详情抽屉。同时保持与本地状态的同步，确保用户操作或 URL 变化时状态一致。

- 引入 `useNavigate` 和 `useRouterState` 实现路由状态管理
- 新增 `useEffect` 监听 URL 中的 `job_id` 并同步到组件状态- 调整岗位选中逻辑以兼容 URL 驱动的状态初始化
- 点击岗位项时更新 URL 查询参数，关闭抽屉时清除 `job_id` 参数

## 描述

<!-- 请清晰、简洁地描述此 PR 的变更内容，并说明相关的动机与背景。 -->

## 变更类型

<!-- 你的代码为本项目引入了哪些类型的变更？在适用的选项中用 `x` 标注 -->

- [ ] Bug 修复（非破坏性更改，用于修复问题）
- [ ] 新功能（非破坏性更改，增加新功能）
- [ ] 其他（未在以上列出的更改）

## 清单

<!-- 提交 PR 前请遵循以下清单，并在完成项目前加上 [x]。也可以在创建 PR 后补充。此清单用于帮助我们在合并前进行检查。 -->

- [ ] 我已阅读 [贡献指南](https://github.com/satnaing/shadcn-admin/blob/main/.github/CONTRIBUTING.md)

## 进一步说明

<!-- 如果这是较大或复杂的变更，请解释你为何选择该方案，以及你考虑过的替代方案等。 -->

## 关联的 Issue

<!-- 如果此 PR 与现有 Issue 相关，请在此处进行链接。 -->

关闭：#<!-- 相关 Issue 编号（如适用） -->