### PR TITLE
feat(mock-interview): 优化模拟面试卡片和记录卡片的展示逻辑

### DIFF
--- a/src/features/mock-interview/components/mock-card.tsx
+++ b/src/features/mock-interview/components/mock-card.tsx
@@ -51,7 +51,7 @@ export default function MockCard({ item, index }: MockCardProps) {
       <div className='bg-white overflow-hidden'>
         <div className='h-[144px] sm:h-[104px] sm:group-hover:h-[144px] transition-all duration-300 ease-out p-5 pt-4 relative'>
           <div className='flex flex-col h-full'>
-            <div className='mt-[4px] font-semibold text-[16px] leading-[24px]'>{item.title}</div>
+            <div className='mt-[4px] font-semibold text-[16px] leading-[24px] line-clamp-1'>{item.title}</div>
             <div 
               className='mt-[4px] text-[12px] leading-[18px] text-muted-foreground line-clamp-2 h-[36px] overflow-hidden flex-shrink-0'
               dangerouslySetInnerHTML={{ __html: item.summary || '' }}

--- a/src/features/mock-interview/records/index.tsx
+++ b/src/features/mock-interview/records/index.tsx
@@ -63,6 +63,7 @@ function RecordCard({ item, onReport, onMore, onReinterview }: { item: MockInter
         </div>
       </div>
       <div className='flex items-center gap-2 shrink-0'>
+        {!reportReady && <span className='text-[12px] text-gray-400'>生成时间约30秒</span>}
         <Button
           size='sm'
           onClick={() => { if (!reportReady) return; onReport() }}


### PR DESCRIPTION
在 MockCard 组件中，添加了文本溢出处理，确保标题在一行内显示。更新 RecordCard 组件，增加生成时间提示，提升用户体验。

## 描述

<!-- 请清晰、简洁地描述此 PR 的变更内容，并说明相关的动机与背景。 -->

## 变更类型

<!-- 你的代码为本项目引入了哪些类型的变更？在适用的选项中用 `x` 标注 -->

- [ ] Bug 修复（非破坏性更改，用于修复问题）
- [ ] 新功能（非破坏性更改，增加新功能）
- [ ] 其他（未在以上列出的更改）

## 清单

<!-- 提交 PR 前请遵循以下清单，并在完成项目前加上 [x]。也可以在创建 PR 后补充。此清单用于帮助我们在合并前进行检查。 -->

- [ ] 我已阅读 [贡献指南](https://github.com/satnaing/shadcn-admin/blob/main/.github/CONTRIBUTING.md)

## 进一步说明

<!-- 如果这是较大或复杂的变更，请解释你为何选择该方案，以及你考虑过的替代方案等。 -->

## 关联的 Issue

<!-- 如果此 PR 与现有 Issue 相关，请在此处进行链接。 -->

关闭：#<!-- 相关 Issue 编号（如适用） -->