### PR TITLE
fix(mock-interview): 点击分类时重置页面并更新状态修复了在点击分类按钮时未重置分页的问题，现在点击任一分类都会将页面重…

### DIFF
--- a/src/features/mock-interview/components/mock-interview-list.tsx
+++ b/src/features/mock-interview/components/mock-interview-list.tsx
@@ -190,9 +190,12 @@ export default function MockInterviewList() {
             return (
               <button
                 key={id}
-                onClick={() => setCategory(id)}
+                onClick={() => {
+                  setPage(1)
+                  setCategory(id)
+                }}
                 className='group inline-flex max-w-[120px] min-w-[88px] shrink-0 flex-col items-center gap-2 text-sm'
-                aria-pressed={active}
+                aria-pressed={active ? 'true' : 'false'}
               >
                 <span
                   className={[

--- a/src/features/mock-interview/index.tsx
+++ b/src/features/mock-interview/index.tsx
@@ -215,9 +215,12 @@ export default function MockInterviewPage() {
               return (
                 <button
                   key={id}
-                  onClick={() => setCategory(id)}
+                  onClick={() => {
+                    setPage(1)
+                    setCategory(id)
+                  }}
                   className='group inline-flex max-w-[120px] min-w-[88px] shrink-0 flex-col items-center gap-2 text-sm'
-                  aria-pressed={active}
+                  aria-pressed={active ? 'true' : 'false'}
                 >
                   <span
                     className={[


### PR DESCRIPTION
…置为第一页，

同时确保 aria-pressed 属性正确反映按钮激活状态。

## 描述

<!-- 请清晰、简洁地描述此 PR 的变更内容，并说明相关的动机与背景。 -->

## 变更类型

<!-- 你的代码为本项目引入了哪些类型的变更？在适用的选项中用 `x` 标注 -->

- [ ] Bug 修复（非破坏性更改，用于修复问题）
- [ ] 新功能（非破坏性更改，增加新功能）
- [ ] 其他（未在以上列出的更改）

## 清单

<!-- 提交 PR 前请遵循以下清单，并在完成项目前加上 [x]。也可以在创建 PR 后补充。此清单用于帮助我们在合并前进行检查。 -->

- [ ] 我已阅读 [贡献指南](https://github.com/satnaing/shadcn-admin/blob/main/.github/CONTRIBUTING.md)

## 进一步说明

<!-- 如果这是较大或复杂的变更，请解释你为何选择该方案，以及你考虑过的替代方案等。 -->

## 关联的 Issue

<!-- 如果此 PR 与现有 Issue 相关，请在此处进行链接。 -->

关闭：#<!-- 相关 Issue 编号（如适用） -->