### PR TITLE
feat(mock-interview): 在模拟面试组件中添加分类ID和分类图标支持

### DIFF
--- a/src/features/mock-interview/components/mock-card.tsx
+++ b/src/features/mock-interview/components/mock-card.tsx
@@ -1,5 +1,6 @@
 // tooltip 取消，直接展示截断
 import type { MockInterviewItem } from '@/features/mock-interview/types'
+import { IconDeviceLaptop } from '@tabler/icons-react'
 
 function gradientClassByIndex(index: number): string {
   const i = index % 9
@@ -16,14 +17,16 @@ function gradientClassByIndex(index: number): string {
   }
 }
 
+
 export interface MockCardProps {
   item: MockInterviewItem
   index: number
+  categories: Array<{ id: number; icon?: string }>
 }
 
 import { useNavigate } from '@tanstack/react-router'
 
-export default function MockCard({ item, index }: MockCardProps) {
+export default function MockCard({ item, index, categories }: MockCardProps) {
   const navigate = useNavigate()
   return (
     <div
@@ -37,10 +40,44 @@ export default function MockCard({ item, index }: MockCardProps) {
       <div className={['relative flex-1 w-full', gradientClassByIndex(index)].join(' ')}>
         {/* 左上角分钟徽标（距上/左16px） */}
         <div className='absolute left-4 top-4 z-10 flex items-center gap-2 text-primary/80 text-xs'>
-          <span className='inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-[11px]'>
-            <span>⏱</span>
+          <span className='inline-flex items-center gap-1 rounded-full bg-white/50 px-2 py-0.5 text-[11px]'>
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M6 1.125C6.18985 1.125 6.34675 1.26608 6.37158 1.44911L6.375 1.5V2.5C6.375 2.70711 6.20711 2.875 6 2.875C5.81015 2.875 5.65325 2.73392 5.62842 2.55089L5.625 2.5V1.5C5.625 1.29289 5.79289 1.125 6 1.125Z" fill="#4E02E4"/>
+              <path d="M6 1.125C8.69261 1.125 10.875 3.30739 10.875 6C10.875 8.69261 8.69261 10.875 6 10.875C3.30739 10.875 1.125 8.69261 1.125 6C1.125 5.39634 1.23903 4.8045 1.45672 4.2413C1.53139 4.04812 1.74852 3.95205 1.9417 4.02672C2.13488 4.10139 2.23095 4.31852 2.15628 4.5117C1.9714 4.99 1.875 5.49036 1.875 6C1.875 8.27839 3.72161 10.125 6 10.125C8.27839 10.125 10.125 8.27839 10.125 6C10.125 3.72161 8.27839 1.875 6 1.875C5.79289 1.875 5.625 1.70711 5.625 1.5C5.625 1.29289 5.79289 1.125 6 1.125Z" fill="#4E02E4"/>
+              <path d="M2.55466 2.5549C2.68779 2.42177 2.89612 2.40967 3.04293 2.51859L3.08499 2.5549L5.55999 5.0299C5.70644 5.17635 5.70644 5.41379 5.55999 5.56023C5.42686 5.69337 5.21852 5.70547 5.07172 5.59654L5.02966 5.56023L2.55466 3.08523C2.40821 2.93879 2.40821 2.70135 2.55466 2.5549Z" fill="#4E02E4"/>
+              <path d="M5.02783 5.02783C5.5648 4.49086 6.4352 4.49086 6.97217 5.02783C7.50904 5.56481 7.5091 6.43523 6.97217 6.97217C6.43523 7.5091 5.56481 7.50904 5.02783 6.97217C4.49086 6.4352 4.49086 5.5648 5.02783 5.02783ZM6.39111 5.51221C6.14569 5.31484 5.78589 5.33032 5.55811 5.55811C5.31403 5.80218 5.31403 6.19782 5.55811 6.44189C5.80219 6.68587 6.19785 6.68594 6.44189 6.44189C6.66961 6.21418 6.68497 5.8543 6.48779 5.60889L6.44189 5.55811L6.39111 5.51221Z" fill="#4E02E4"/>
+            </svg>
             <span>{item.durationMinutes}分钟</span>
           </span>
+        </div>
+        
+        {/* 右上角分类图标（距上/右16px） */}
+        <div className='absolute right-4 top-4 z-10'>
+          <div className='flex h-10 w-10 items-center justify-center rounded-full bg-[#4E02E4]/20 backdrop-blur-sm'>
+            {(() => {
+              // 根据 item.category_id 找到对应的分类图标
+              const categoryData = categories.find(cat => cat.id === item.category_id)
+              const categoryIcon = categoryData?.icon
+              
+              return categoryIcon ? (
+                <span
+                  className='h-6 w-6 bg-white drop-shadow-sm'
+                  style={{
+                    WebkitMaskImage: `url(${categoryIcon})`,
+                    maskImage: `url(${categoryIcon})`,
+                    WebkitMaskRepeat: 'no-repeat',
+                    maskRepeat: 'no-repeat',
+                    WebkitMaskPosition: 'center',
+                    maskPosition: 'center',
+                    WebkitMaskSize: 'contain',
+                    maskSize: 'contain',
+                  }}
+                />
+              ) : (
+                <IconDeviceLaptop className='h-6 w-6 text-white drop-shadow-sm' />
+              )
+            })()}
+          </div>
         </div>
       </div>
 

--- a/src/features/mock-interview/components/mock-interview-list.tsx
+++ b/src/features/mock-interview/components/mock-interview-list.tsx
@@ -270,9 +270,11 @@ export default function MockInterviewList() {
                   summary: it.description,
                   durationMinutes: it.interview_duration_minutes,
                   category: it.category_name,
+                  category_id: it.category_id,
                   id: it.id,
                 }}
                 index={idx}
+                categories={categories}
               />
             ))}
           </div>

--- a/src/features/mock-interview/index.tsx
+++ b/src/features/mock-interview/index.tsx
@@ -295,9 +295,11 @@ export default function MockInterviewPage() {
                     summary: it.description,
                     durationMinutes: it.interview_duration_minutes,
                     category: it.category_name,
+                    category_id: it.category_id,
                     id: it.id,
                   }}
                   index={idx}
+                  categories={categories}
                 />
               ))}
             </div>

--- a/src/features/mock-interview/types.ts
+++ b/src/features/mock-interview/types.ts
@@ -4,6 +4,7 @@ export interface MockInterviewItem {
   summary: string
   durationMinutes: number
   category: string
+  category_id: number
   id: number
 }
 


### PR DESCRIPTION
更新了 MockInterviewItem 接口，添加了 category_id 字段，并在 MockCard 组件中实现了根据分类ID显示相应的分类图标。确保在 MockInterviewPage 和 MockInterviewList 组件中传递分类数据。

## 描述

<!-- 请清晰、简洁地描述此 PR 的变更内容，并说明相关的动机与背景。 -->

## 变更类型

<!-- 你的代码为本项目引入了哪些类型的变更？在适用的选项中用 `x` 标注 -->

- [ ] Bug 修复（非破坏性更改，用于修复问题）
- [ ] 新功能（非破坏性更改，增加新功能）
- [ ] 其他（未在以上列出的更改）

## 清单

<!-- 提交 PR 前请遵循以下清单，并在完成项目前加上 [x]。也可以在创建 PR 后补充。此清单用于帮助我们在合并前进行检查。 -->

- [ ] 我已阅读 [贡献指南](https://github.com/satnaing/shadcn-admin/blob/main/.github/CONTRIBUTING.md)

## 进一步说明

<!-- 如果这是较大或复杂的变更，请解释你为何选择该方案，以及你考虑过的替代方案等。 -->

## 关联的 Issue

<!-- 如果此 PR 与现有 Issue 相关，请在此处进行链接。 -->

关闭：#<!-- 相关 Issue 编号（如适用） -->