### PR TITLE
refactor(finish): 移除面试节点补偿上报逻辑

### DIFF
--- a/src/features/finish/index.tsx
+++ b/src/features/finish/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useNavigate } from '@tanstack/react-router'
 import { handleServerError } from '@/utils/handle-server-error'
 import { Button } from '@/components/ui/button'
@@ -11,7 +11,6 @@ import { FeedbackParams, fetchFeedback } from './api'
 import { toast } from 'sonner'
 import emptyStar from '@/assets/images/empty-start.svg'
 import filledStar from '@/assets/images/full-start.svg'
-import { NodeActionTrigger, postNodeAction } from '@/features/interview/api'
 import { reportFinishFeedbackLowScore } from '@/lib/apm'
 import { useJobDetailQuery } from '@/features/jobs/api'
 
@@ -59,28 +58,6 @@ export default function FinishPage() {
     const val = sp.get('is_canceled') ?? sp.get('isCanceled')
     return val === 'true'
   }, [])
-
-  // interview 节点 id（用于补偿上报 NodeAction）
-  const interviewNodeId = useMemo(() => {
-    const sp = new URLSearchParams(window.location.search)
-    const nodeId = sp.get('interview_node_id')
-    if (!nodeId) return undefined
-    const n = Number(nodeId)
-    return Number.isNaN(n) ? (nodeId as string) : (n as number)
-  }, [])
-
-  // 进入页面即进行一次补偿上报（submit），失败不阻塞流程
-  useEffect(() => {
-    ;(async () => {
-      try {
-        if (interviewNodeId != null && !isMock && job != null) {
-          await postNodeAction({ node_id: interviewNodeId, trigger: NodeActionTrigger.Submit, result_data: {} })
-        }
-      } catch (_e) {
-        // ignore
-      }
-    })()
-  }, [interviewNodeId, isMock, job])
 
   // 把 prepare 页面的参数原样透传回去，便于返回时延续上下文
   const prepareSearch = useMemo(() => {


### PR DESCRIPTION
- 删除了未使用的 `useEffect` 补偿上报逻辑
- 移除了 `interviewNodeId` 的计算逻辑
- 清理了相关导入和类型引用
- 简化了页面初始化流程

## 描述

<!-- 请清晰、简洁地描述此 PR 的变更内容，并说明相关的动机与背景。 -->

## 变更类型

<!-- 你的代码为本项目引入了哪些类型的变更？在适用的选项中用 `x` 标注 -->

- [ ] Bug 修复（非破坏性更改，用于修复问题）
- [ ] 新功能（非破坏性更改，增加新功能）
- [ ] 其他（未在以上列出的更改）

## 清单

<!-- 提交 PR 前请遵循以下清单，并在完成项目前加上 [x]。也可以在创建 PR 后补充。此清单用于帮助我们在合并前进行检查。 -->

- [ ] 我已阅读 [贡献指南](https://github.com/satnaing/shadcn-admin/blob/main/.github/CONTRIBUTING.md)

## 进一步说明

<!-- 如果这是较大或复杂的变更，请解释你为何选择该方案，以及你考虑过的替代方案等。 -->

## 关联的 Issue

<!-- 如果此 PR 与现有 Issue 相关，请在此处进行链接。 -->

关闭：#<!-- 相关 Issue 编号（如适用） -->