### PR TITLE
feat(mock-interview): 更新导航和选项卡状态管理

### DIFF
--- a/src/features/interview-reports/index.tsx
+++ b/src/features/interview-reports/index.tsx
@@ -84,11 +84,7 @@ export default function InterviewReports() {
             variant='ghost'
             size='sm'
             onClick={() => {
-              if (typeof window !== 'undefined' && window.history.length > 1) {
-                window.history.back()
-              } else {
-                navigate({ to: '/mock-interview/records' })
-              }
+              navigate({ to: '/mock-interview', search: { tab: 'records' } })
             }}
           >
             <IconArrowLeft className='h-4 w-4' /> 返回

--- a/src/features/mock-interview/tabs-page.tsx
+++ b/src/features/mock-interview/tabs-page.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useNavigate, useSearch } from '@tanstack/react-router'
 import { Header } from '@/components/layout/header'
 import { Main } from '@/components/layout/main'
 import { Tabs, TabsContent } from '@/components/ui/tabs'
@@ -7,7 +8,14 @@ import MockInterviewList from '@/features/mock-interview/components/mock-intervi
 import MockInterviewRecords from '@/features/mock-interview/components/mock-interview-records'
 
 export default function MockInterviewTabsPage() {
-  const [activeTab, setActiveTab] = useState('interview')
+  const navigate = useNavigate()
+  const search = useSearch({ from: '/_public/mock-interview/' }) as { tab?: string }
+  const [activeTab, setActiveTab] = useState(search?.tab === 'records' ? 'records' : 'interview')
+  
+  const handleTabChange = (tab: string) => {
+    setActiveTab(tab)
+    navigate({ to: '/mock-interview', search: { tab } })
+  }
 
   return (
     <>
@@ -21,7 +29,7 @@ export default function MockInterviewTabsPage() {
         <Tabs value={activeTab} onValueChange={setActiveTab} className='flex-1 flex flex-col min-h-0'>
           <div className='flex border-b border-border shrink-0'>
             <button
-              onClick={() => setActiveTab('interview')}
+              onClick={() => handleTabChange('interview')}
               className={`px-4 py-2 text-lg font-medium border-b-2 transition-colors ${
                 activeTab === 'interview'
                   ? 'border-[#4E02E4] text-[#4E02E4]'
@@ -31,7 +39,7 @@ export default function MockInterviewTabsPage() {
               模拟面试
             </button>
             <button
-              onClick={() => setActiveTab('records')}
+              onClick={() => handleTabChange('records')}
               className={`px-4 py-2 text-lg font-medium border-b-2 transition-colors ${
                 activeTab === 'records'
                   ? 'border-[#4E02E4] text-[#4E02E4]'

--- a/src/routes/_public/mock-interview/index.tsx
+++ b/src/routes/_public/mock-interview/index.tsx
@@ -1,13 +1,22 @@
 import { createFileRoute } from '@tanstack/react-router'
 import MockInterviewTabsPage from '@/features/mock-interview/tabs-page'
 
+type MockInterviewSearch = {
+  page?: number
+  pageSize?: number
+  q?: string
+  category?: string
+  tab?: string
+}
+
 export const Route = createFileRoute('/_public/mock-interview/')({
-  validateSearch: (search: { page?: number; pageSize?: number; q?: string; category?: string }) => {
+  validateSearch: (search: MockInterviewSearch): MockInterviewSearch => {
     return {
       page: typeof search?.page === 'number' && search.page > 0 ? search.page : 1,
       pageSize: typeof search?.pageSize === 'number' && search.pageSize > 0 ? search.pageSize : 12,
       q: typeof search?.q === 'string' ? search.q : '',
       category: typeof search?.category === 'string' ? search.category : undefined,
+      tab: typeof search?.tab === 'string' ? search.tab : 'interview',
     }
   },
   component: () => <MockInterviewTabsPage />,


### PR DESCRIPTION
优化了模拟面试页面的导航逻辑，点击返回按钮时直接导航到记录选项卡。同时，重构了选项卡切换逻辑，确保在切换选项卡时更新状态并保持URL中的查询参数。增加了对选项卡状态的管理，使其在页面加载时根据查询参数设置初始状态。

## 描述

<!-- 请清晰、简洁地描述此 PR 的变更内容，并说明相关的动机与背景。 -->

## 变更类型

<!-- 你的代码为本项目引入了哪些类型的变更？在适用的选项中用 `x` 标注 -->

- [ ] Bug 修复（非破坏性更改，用于修复问题）
- [ ] 新功能（非破坏性更改，增加新功能）
- [ ] 其他（未在以上列出的更改）

## 清单

<!-- 提交 PR 前请遵循以下清单，并在完成项目前加上 [x]。也可以在创建 PR 后补充。此清单用于帮助我们在合并前进行检查。 -->

- [ ] 我已阅读 [贡献指南](https://github.com/satnaing/shadcn-admin/blob/main/.github/CONTRIBUTING.md)

## 进一步说明

<!-- 如果这是较大或复杂的变更，请解释你为何选择该方案，以及你考虑过的替代方案等。 -->

## 关联的 Issue

<!-- 如果此 PR 与现有 Issue 相关，请在此处进行链接。 -->

关闭：#<!-- 相关 Issue 编号（如适用） -->