### PR TITLE
feat(interview): 实现面试页面的移动端适配和布局优化

### DIFF
--- a/src/features/interview/components/annotate-test-pending.tsx
+++ b/src/features/interview/components/annotate-test-pending.tsx
@@ -1,0 +1,75 @@
+import { Button } from '@/components/ui/button'
+import { toast } from 'sonner'
+import { IconArrowRight } from '@tabler/icons-react'
+
+interface AnnotateTestPendingProps {
+  onTaskComplete: () => void
+}
+
+/**
+ * 标注测试待完成视图
+ * 引导用户前往 Xpert Studio 完成标注测试任务
+ */
+export function AnnotateTestPending({ onTaskComplete }: AnnotateTestPendingProps) {
+  const handleSubmit = () => {
+    // TODO: 实现提交审核逻辑
+    toast.success('已提交审核')
+    // TODO：调用接口查询试标任务状态的接口，如果任务状态为已完成，则调用 onTaskComplete 方法
+    onTaskComplete()
+  }
+
+  return (
+    <div className='flex-1 flex items-center justify-center min-h-[60vh]'>
+      <div className='flex flex-col items-center space-y-6 max-w-[520px] px-6'>
+        {/* Logo 区域 */}
+        <div className='flex items-center gap-6'>
+          <div>
+            <img
+              src='https://dnu-cdn.xpertiise.com/design-assets/logo-no-padding.svg'
+              alt='一面千识'
+              className='h-[100px] w-auto object-contain'
+            />
+            <p className='text-sm py-2 text-center text-foreground leading-relaxed'>一面千识</p>
+          </div>
+          
+          <IconArrowRight className='h-8 w-8 text-muted-foreground top-4' />
+          <div>
+            <img
+              src='https://dnu-cdn.xpertiise.com/design-assets/logo-no-padding-blue.svg'
+              alt='Xpert Studio'
+              className='h-[100px] w-auto object-contain'
+            />
+            <p className='text-sm py-2 text-center text-foreground leading-relaxed'>Xpert Studio</p>
+          </div>
+
+        </div>
+
+        {/* 说明文字 */}
+        <div className='text-center space-y-4'>
+          <p className='text-lg text-foreground leading-relaxed'>
+            请点击链接前往{' '}
+            <a
+              href='https://xpertstudio.com'
+              target='_blank'
+              rel='noopener noreferrer'
+              className='text-primary underline font-medium'
+            >
+              Xpert Studio
+            </a>
+            ，使用一面千识的注册手机号短信登陆后，完成【项目名】下所有任务。确认完成后请点击下方按钮提交审核
+          </p>
+        </div>
+
+        {/* 提交按钮 */}
+        <Button
+          onClick={handleSubmit}
+          className='h-[44px] w-[200px] bg-[linear-gradient(90deg,#4E02E4_10%,#C994F7_100%)] text-white'
+        >
+          我已完成任务，提交审核
+        </Button>
+
+      </div>
+    </div>
+  )
+}
+

--- a/src/features/interview/session-view-page/components/chat-message-view.tsx
+++ b/src/features/interview/session-view-page/components/chat-message-view.tsx
@@ -53,23 +53,18 @@ export const ChatMessageView = ({ className, children, ...props }: ChatProps) =>
 
   return (
     <div className={cn('h-full w-full', className)} {...props}>
-      <div ref={scrollContentRef} className='grid h-full w-full grid-cols-3'>
-        <div className='col-span-2' />
-        <div className='col-span-1 flex h-full flex-col justify-center px-8'>
-          <div className='max-w-md space-y-3'>
-            <div className='overflow-y-auto whitespace-pre-wrap px-1'>
-              <ul className='space-y-3'>
-                {agentMessages.map((m, idx) => (
-                  <li key={`${m.time}-${idx}`} className='group flex flex-col gap-0.5'>
-                    <span className='ml-auto max-w-5/5 rounded-[20px] py-2 text-blue-600 leading-relaxed text-base/6'>
-                      {m.value}
-                    </span>
-                  </li>
-                ))}
-              </ul>
-              {children}
-            </div>
-          </div>
+      <div ref={scrollContentRef} className='h-full w-full'>
+        <div className='overflow-y-auto whitespace-pre-wrap'>
+          <ul className='space-y-3'>
+            {agentMessages.map((m, idx) => (
+              <li key={`${m.time}-${idx}`} className='group flex flex-col gap-0.5'>
+                <span className='ml-auto max-w-5/5 rounded-[20px] py-2 text-blue-600 leading-relaxed text-base/6'>
+                  {m.value}
+                </span>
+              </li>
+            ))}
+          </ul>
+          {children}
         </div>
       </div>
     </div>

--- a/src/features/interview/session-view-page/components/desktop-layout.tsx
+++ b/src/features/interview/session-view-page/components/desktop-layout.tsx
@@ -1,0 +1,65 @@
+import InterviewTimer from './interview-timer'
+import { ConnectionQualityBars } from '@/components/interview/connection-quality-bars'
+import { ChatMessageView } from './chat-message-view'
+import ConnectionStatus from './connection-status'
+import LiteAgentTile from './lite-agent-tile'
+import { Button } from '@/components/ui/button'
+import LocalVideoTile from './local-video-tile'
+import RecordingIndicator from './recording-indicator'
+
+interface DesktopLayoutProps {
+  onLeave: () => void
+}
+
+export default function DesktopLayout({ onLeave }: DesktopLayoutProps) {
+  return (
+    <div className='space-y-6'>
+      {/* 顶部：计时器 + 网络状态 */}
+      <div className='fixed top-20 right-6 z-50 flex items-center gap-3'>
+        <InterviewTimer active={true} />
+        <ConnectionQualityBars />
+      </div>
+
+      {/* 右侧：字幕区域（PC端栅格布局） */}
+      <div className='fixed inset-0 z-40'>
+        <div className='grid h-full w-full grid-cols-3'>
+          <div className='col-span-2' />
+          <div className='col-span-1 flex h-full flex-col justify-center px-8'>
+            <div className='max-w-md space-y-3 px-1'>
+              <ChatMessageView>
+                <ConnectionStatus />
+              </ChatMessageView>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* AgentTile 居中 */}
+      <div className='fixed inset-0 z-20 flex items-center justify-center'>
+        <LiteAgentTile className='h-64 w-96' />
+      </div>
+
+      {/* 底部：左本地视频 | 中录音指示器占位 | 右控制条 */}
+      <div className='fixed inset-x-0 bottom-12 z-50 px-6'>
+        <div className='flex w-full items-end gap-4'>
+          <div className='min-w-[8rem] flex-1'>
+            <LocalVideoTile className='h-48 w-64 rounded-md overflow-hidden border bg-black' />
+          </div>
+          <div className='flex flex-1 justify-center -mb-10'>
+            <RecordingIndicator />
+          </div>
+          <div className='flex flex-1 justify-end pointer-events-auto mb-4'>
+            <div className='flex flex-col rounded-[31px]'>
+              <div className='flex flex-row justify-end gap-1'>
+                <Button variant='default' onClick={onLeave} className='font-mono'>
+                  放弃面试
+                </Button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+

--- a/src/features/interview/session-view-page/components/local-video-tile.tsx
+++ b/src/features/interview/session-view-page/components/local-video-tile.tsx
@@ -30,7 +30,7 @@ export default function LocalVideoTile({ stream, recordingStatus, className, ...
       userId!,
       'local-video-player',
       false,
-      VideoRenderMode.RENDER_MODE_FILL
+      VideoRenderMode.RENDER_MODE_FIT
     )
   }
 

--- a/src/features/interview/session-view-page/components/mobile-layout.tsx
+++ b/src/features/interview/session-view-page/components/mobile-layout.tsx
@@ -1,0 +1,55 @@
+import InterviewTimer from './interview-timer'
+import { ConnectionQualityBars } from '@/components/interview/connection-quality-bars'
+import LiteAgentTile from './lite-agent-tile'
+import { Button } from '@/components/ui/button'
+import LocalVideoTile from './local-video-tile'
+import RecordingIndicator from './recording-indicator'
+import { ChatMessageView } from './chat-message-view'
+import ConnectionStatus from './connection-status'
+
+interface MobileLayoutProps {
+  onLeave: () => void
+}
+
+export default function MobileLayout({ onLeave }: MobileLayoutProps) {
+  return (
+    <div className='fixed inset-0 flex flex-col bg-gradient-to-b from-purple-100 to-purple-200'>
+      {/* 上方：InterviewTimer 和 ConnectionQualityBars，靠左布局 */}
+      <div className='flex items-center gap-2 px-4 pt-4'>
+        <InterviewTimer active={true} />
+        <ConnectionQualityBars />
+      </div>
+
+      {/* 第二行：LocalVideoTile 在左，LiteAgentTile 居中 */}
+      <div className='flex items-center px-4'>
+        <LocalVideoTile className='h-32 w-21 flex-shrink-0 rounded-2xl overflow-hidden bg-black' />
+        <div className='flex flex-2 items-center justify-center'>
+          <LiteAgentTile className='h-48 w-48' />
+        </div>
+        <div className='w-24'></div>
+      </div>
+
+      {/* 中间部分：flex-1 填满剩余空间，字幕区域（移动端居中布局） */}
+      <div className='flex-1 flex-col items-center justify-start px-6'>
+        <div className='w-full max-w-md'>
+          <ChatMessageView>
+            <ConnectionStatus className='w-full scale-[0.8]' />
+          </ChatMessageView>
+        </div>
+      </div>
+
+      {/* 下方：RecordingIndicator 和「放弃按钮」，flex-col 居中布局 */}
+      <div className='flex flex-col items-center pb-8'>
+        <RecordingIndicator className='w-full px-[50px]' />
+        <Button
+          variant='default'
+          onClick={onLeave}
+          className='font-mono'
+        >
+          放弃面试
+        </Button>
+      </div>
+    </div>
+  )
+}
+

--- a/src/features/interview/session-view-page/index.tsx
+++ b/src/features/interview/session-view-page/index.tsx
@@ -1,24 +1,20 @@
 import { useCallback, useState, useEffect, useRef } from 'react'
 import { Main } from '@/components/layout/main'
 import { Separator } from '@/components/ui/separator'
-import InterviewTimer from './components/interview-timer'
-import { ConnectionQualityBars } from '@/components/interview/connection-quality-bars'
-import { ChatMessageView } from './components/chat-message-view'
-import ConnectionStatus from './components/connection-status'
-import LiteAgentTile from './components/lite-agent-tile'
-import { Button } from '@/components/ui/button'
-import LocalVideoTile from './components/local-video-tile'
-import RecordingIndicator from './components/recording-indicator'
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
 import { useLeave, useInterviewFinish } from './lib/useCommon'
 import useAgentApm from './lib/useAgentApm'
 import { userEvent } from '@/lib/apm'
 import { useRoomStore } from '@/stores/interview/room'
 import { useNavigate } from '@tanstack/react-router'
 import { useJobDetailQuery } from '@/features/jobs/api'
+import { useIsMobile } from '@/hooks/use-mobile'
+import DesktopLayout from './components/desktop-layout'
+import MobileLayout from './components/mobile-layout'
 
 export default function InterviewSessionViewPage() {
-
+  const isMobile = useIsMobile()
   const [confirmEndOpen, setConfirmEndOpen] = useState(false)
   const leaveRoom = useLeave()
   useInterviewFinish()
@@ -98,63 +94,58 @@ export default function InterviewSessionViewPage() {
 
   return (
     <>
-      <Main fixed>
-
-        <Separator className='my-4 lg:my-6' />
-
-        <div className='space-y-6'>
-          {/* 顶部：计时器 + 网络状态 */}
-          <div className='fixed top-20 right-6 z-50 flex items-center gap-3'>
-            <InterviewTimer active={true} />
-            <ConnectionQualityBars />
-          </div>
-
-          {/* 右侧：字幕区域（保持结构一致） */}
-          <ChatMessageView className='fixed inset-0 z-40' >
-            <ConnectionStatus />
-          </ChatMessageView>
-
-
-          {/* AgentTile 居中 */}
-          <div className='fixed inset-0 z-20 flex items-center justify-center'>
-            <LiteAgentTile className='h-64 w-96' />
-          </div>
-
-          {/* 底部：左本地视频 | 中录音指示器占位 | 右控制条 */}
-          <div className='fixed inset-x-0 bottom-12 z-50 px-6'>
-            <div className='flex w-full items-end gap-4'>
-              <div className='min-w-[8rem] flex-1'>
-                <LocalVideoTile className='h-48 w-64 rounded-md overflow-hidden border bg-black' />
-              </div>
-              <div className='flex flex-1 justify-center -mb-10'>
-                <RecordingIndicator />
-              </div>
-              <div className='flex flex-1 justify-end pointer-events-auto mb-4'>
-                <div className={`flex flex-col rounded-[31px]`}>
-                  <div className='flex flex-row justify-end gap-1'>
-                    <Button variant='default' onClick={onLeave} className='font-mono'>放弃面试</Button>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </Main>
-      <Dialog open={confirmEndOpen} onOpenChange={setConfirmEndOpen}>
-        <DialogContent className='sm:max-w-md'>
-          <DialogHeader className='text-left'>
-            <DialogTitle>确认要放弃面试吗？</DialogTitle>
-            <DialogDescription>放弃面试将没有面试结果，若需要请重新面试</DialogDescription>
-          </DialogHeader>
-          <DialogFooter className='gap-2'>
-            <Button onClick={() => setConfirmEndOpen(false)}>继续面试</Button>
-            <Button variant='outline' onClick={() => {
-              setConfirmEndOpen(false)
-              performEndInterview()
-            }}>确定放弃</Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      {isMobile ? (
+        <>
+          <MobileLayout onLeave={onLeave} />
+          <Dialog open={confirmEndOpen} onOpenChange={setConfirmEndOpen}>
+            <DialogContent className='sm:max-w-md'>
+              <DialogHeader className='text-left'>
+                <DialogTitle>确认要放弃面试吗？</DialogTitle>
+                <DialogDescription>放弃面试将没有面试结果，若需要请重新面试</DialogDescription>
+              </DialogHeader>
+              <DialogFooter className='gap-2'>
+                <Button onClick={() => setConfirmEndOpen(false)}>继续面试</Button>
+                <Button
+                  variant='outline'
+                  onClick={() => {
+                    setConfirmEndOpen(false)
+                    performEndInterview()
+                  }}
+                >
+                  确定放弃
+                </Button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
+        </>
+      ) : (
+        <>
+          <Main fixed>
+            <Separator className='my-4 lg:my-6' />
+            <DesktopLayout onLeave={onLeave} />
+          </Main>
+          <Dialog open={confirmEndOpen} onOpenChange={setConfirmEndOpen}>
+            <DialogContent className='sm:max-w-md'>
+              <DialogHeader className='text-left'>
+                <DialogTitle>确认要放弃面试吗？</DialogTitle>
+                <DialogDescription>放弃面试将没有面试结果，若需要请重新面试</DialogDescription>
+              </DialogHeader>
+              <DialogFooter className='gap-2'>
+                <Button onClick={() => setConfirmEndOpen(false)}>继续面试</Button>
+                <Button
+                  variant='outline'
+                  onClick={() => {
+                    setConfirmEndOpen(false)
+                    performEndInterview()
+                  }}
+                >
+                  确定放弃
+                </Button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
+        </>
+      )}
     </>
   )
 }


### PR DESCRIPTION
- 重构面试页面布局，支持桌面端和移动端自适应
- 新增 DesktopLayout 和 MobileLayout 组件分离不同端的 UI 结构
- 调整本地视频渲染模式为 FIT 以优化显示效果 -优化聊天消息区域的样式与结构，提升可读性
- 添加标注测试待完成引导页面，集成提交审核功能
- 移动端采用弹性布局，确保元素在不同屏幕下的合理展示- 桌面端保留原有栅格系统，保证三栏布局的一致性

## 描述

<!-- 请清晰、简洁地描述此 PR 的变更内容，并说明相关的动机与背景。 -->

## 变更类型

<!-- 你的代码为本项目引入了哪些类型的变更？在适用的选项中用 `x` 标注 -->

- [ ] Bug 修复（非破坏性更改，用于修复问题）
- [ ] 新功能（非破坏性更改，增加新功能）
- [ ] 其他（未在以上列出的更改）

## 清单

<!-- 提交 PR 前请遵循以下清单，并在完成项目前加上 [x]。也可以在创建 PR 后补充。此清单用于帮助我们在合并前进行检查。 -->

- [ ] 我已阅读 [贡献指南](https://github.com/satnaing/shadcn-admin/blob/main/.github/CONTRIBUTING.md)

## 进一步说明

<!-- 如果这是较大或复杂的变更，请解释你为何选择该方案，以及你考虑过的替代方案等。 -->

## 关联的 Issue

<!-- 如果此 PR 与现有 Issue 相关，请在此处进行链接。 -->

关闭：#<!-- 相关 Issue 编号（如适用） -->