### PR TITLE
fix(rtc): 禁用默认音频捕获增强功能

### DIFF
--- a/src/features/interview/session-view-page/lib/RtcClient.ts
+++ b/src/features/interview/session-view-page/lib/RtcClient.ts
@@ -321,14 +321,14 @@ export class RTCClient {
    * @param config 
    */
   setAudioCaptureConfig = async (config: TrackCaptureConfig = {
-    noiseSuppression: true,
-    echoCancellation: true,
-    autoGainControl: true,
+    noiseSuppression: false,
+    echoCancellation: false,
+    autoGainControl: false,
   }) => {
     await this.engine.setAudioCaptureConfig({
-      noiseSuppression: config.noiseSuppression ?? true,
-      echoCancellation: config.echoCancellation ?? true,
-      autoGainControl: config.autoGainControl ?? true,
+      noiseSuppression: config.noiseSuppression ?? false,
+      echoCancellation: config.echoCancellation ?? false,
+      autoGainControl: config.autoGainControl ?? false,
     });
   };
 


### PR DESCRIPTION
- 将 noiseSuppression 默认值从 true 改为 false- 将 echoCancellation 默认值从 true 改为 false
- 将 autoGainControl 默认值从 true 改为 false
- 更新音频捕获配置逻辑以匹配新的默认值

## 描述

<!-- 请清晰、简洁地描述此 PR 的变更内容，并说明相关的动机与背景。 -->

## 变更类型

<!-- 你的代码为本项目引入了哪些类型的变更？在适用的选项中用 `x` 标注 -->

- [ ] Bug 修复（非破坏性更改，用于修复问题）
- [ ] 新功能（非破坏性更改，增加新功能）
- [ ] 其他（未在以上列出的更改）

## 清单

<!-- 提交 PR 前请遵循以下清单，并在完成项目前加上 [x]。也可以在创建 PR 后补充。此清单用于帮助我们在合并前进行检查。 -->

- [ ] 我已阅读 [贡献指南](https://github.com/satnaing/shadcn-admin/blob/main/.github/CONTRIBUTING.md)

## 进一步说明

<!-- 如果这是较大或复杂的变更，请解释你为何选择该方案，以及你考虑过的替代方案等。 -->

## 关联的 Issue

<!-- 如果此 PR 与现有 Issue 相关，请在此处进行链接。 -->

关闭：#<!-- 相关 Issue 编号（如适用） -->