### PR TITLE
feat(interview):为连接状态组件添加移动端适配

### DIFF
--- a/src/features/interview/session-view-page/components/connection-status.tsx
+++ b/src/features/interview/session-view-page/components/connection-status.tsx
@@ -2,6 +2,7 @@
 
 import { cn } from '@/lib/utils'
 import { useRoomStore } from '@/stores/interview/room'
+import { useIsMobile } from '@/hooks/use-mobile'
 
 function getStatusInfo(params: { isThinking: boolean; isTalking: boolean }) {
   const { isThinking, isTalking } = params
@@ -10,10 +11,16 @@ function getStatusInfo(params: { isThinking: boolean; isTalking: boolean }) {
   return { text: '聆听中', color: 'bg-green-400', pulse: true }
 }
 
-export default function ConnectionStatus({ className }: { className?: string }) {
+interface ConnectionStatusProps {
+  className?: string
+}
+
+// Desktop 版本
+function DesktopConnectionStatus({ className }: ConnectionStatusProps) {
   const isAIThinking = useRoomStore((s) => s.isAIThinking)
   const isAITalking = useRoomStore((s) => s.isAITalking)
   const status = getStatusInfo({ isThinking: isAIThinking, isTalking: isAITalking })
+  
   return (
     <div
       className={cn(
@@ -23,12 +30,47 @@ export default function ConnectionStatus({ className }: { className?: string }) 
         className,
       )}
     >
-      <div className={cn('h-2 w-2 rounded-full', status.color, status.pulse && 'animate-pulse')} />
-      <span className='text-white text-[14px] leading-[100%] tracking-[0.35px] font-medium font-["Noto_Sans_SC"]'>
+      <div className={cn('h-2 w-2 rounded-full shrink-0', status.color, status.pulse && 'animate-pulse')} />
+      <span className='text-white text-[14px] leading-[100%] tracking-[0.35px] font-medium font-["Noto_Sans_SC"] whitespace-nowrap'>
         {status.text}
       </span>
     </div>
   )
+}
+
+// Mobile 版本
+function MobileConnectionStatus({ className }: ConnectionStatusProps) {
+  const isAIThinking = useRoomStore((s) => s.isAIThinking)
+  const isAITalking = useRoomStore((s) => s.isAITalking)
+  const status = getStatusInfo({ isThinking: isAIThinking, isTalking: isAITalking })
+  
+  return (
+    <div
+      className={cn(
+        'flex items-center gap-2 justify-center rounded-[31px] mt-4 mb-1',
+        'bg-[#DBB8FA] border-[0.5px] border-[rgba(255,255,255,0.12)]',
+        'shadow-[0_0_4px_0_rgba(0,0,0,0.25)]',
+        'w-[98px] px-3 py-2',
+        className,
+      )}
+    >
+      <div className={cn('h-2 w-2 rounded-full shrink-0', status.color, status.pulse && 'animate-pulse')} />
+      <span className='text-white text-[9px] leading-[100%] tracking-[0.35px] font-medium font-["Noto_Sans_SC"] whitespace-nowrap'>
+        {status.text}
+      </span>
+    </div>
+  )
+}
+
+// 主组件：根据设备类型渲染对应版本
+export default function ConnectionStatus({ className }: ConnectionStatusProps) {
+  const isMobile = useIsMobile()
+  
+  if (isMobile) {
+    return <MobileConnectionStatus className={className} />
+  }
+  
+  return <DesktopConnectionStatus className={className} />
 }
 
 

--- a/src/features/interview/session-view-page/components/mobile-layout.tsx
+++ b/src/features/interview/session-view-page/components/mobile-layout.tsx
@@ -33,7 +33,7 @@ export default function MobileLayout({ onLeave }: MobileLayoutProps) {
       <div className='flex-1 flex-col items-center justify-start px-6'>
         <div className='w-full max-w-md'>
           <ChatMessageView>
-            <ConnectionStatus className='w-full scale-[0.8]' />
+            <ConnectionStatus className='scale-[0.8] mx-auto' />
           </ChatMessageView>
         </div>
       </div>


### PR DESCRIPTION
- 新增移动端专用连接状态组件 MobileConnectionStatus
- 拆分桌面端连接状态组件为 DesktopConnectionStatus
- 添加 useIsMobile 钩子检测设备类型
- 根据设备类型动态渲染对应的连接状态组件
- 调整移动端连接状态样式以适应小屏幕显示
- 修改移动端布局中连接状态的宽度和居中样式

## 描述

<!-- 请清晰、简洁地描述此 PR 的变更内容，并说明相关的动机与背景。 -->

## 变更类型

<!-- 你的代码为本项目引入了哪些类型的变更？在适用的选项中用 `x` 标注 -->

- [ ] Bug 修复（非破坏性更改，用于修复问题）
- [ ] 新功能（非破坏性更改，增加新功能）
- [ ] 其他（未在以上列出的更改）

## 清单

<!-- 提交 PR 前请遵循以下清单，并在完成项目前加上 [x]。也可以在创建 PR 后补充。此清单用于帮助我们在合并前进行检查。 -->

- [ ] 我已阅读 [贡献指南](https://github.com/satnaing/shadcn-admin/blob/main/.github/CONTRIBUTING.md)

## 进一步说明

<!-- 如果这是较大或复杂的变更，请解释你为何选择该方案，以及你考虑过的替代方案等。 -->

## 关联的 Issue

<!-- 如果此 PR 与现有 Issue 相关，请在此处进行链接。 -->

关闭：#<!-- 相关 Issue 编号（如适用） -->