### PR TITLE
feat(interview): 添加回到首页按钮并调整布局

### DIFF
--- a/src/features/interview/prepare.tsx
+++ b/src/features/interview/prepare.tsx
@@ -849,8 +849,13 @@ export default function InterviewPreparePage({ jobId, inviteToken, isSkipConfirm
                 <span className='ml-1 text-primary text-sm'>您可以离开当前页面啦</span>
               </div>
               {interviewNodeStatus === JobApplyNodeStatus.CompletedPendingReview && (
-                <div className='my-8'>
-                  <Button onClick={() => setReinterviewOpen(true)}>重新面试</Button>
+                <div className='flex gap-4 items-center justify-center'>
+                  <div className='my-8'>
+                    <Button onClick={() => setReinterviewOpen(true)}>重新面试</Button>
+                  </div>
+                  <div className='my-8'>
+                    <Button variant='outline' onClick={() => navigate({ to: '/home' })}>回到首页</Button>
+                  </div>
                 </div>
               )}
             </div>


### PR DESCRIPTION
- 在面试完成待审核状态下添加回到首页按钮
- 调整重新面试和回到首页按钮的布局为水平排列
- 使用outline样式区分回到首页按钮的视觉层级

## 描述

<!-- 请清晰、简洁地描述此 PR 的变更内容，并说明相关的动机与背景。 -->

## 变更类型

<!-- 你的代码为本项目引入了哪些类型的变更？在适用的选项中用 `x` 标注 -->

- [ ] Bug 修复（非破坏性更改，用于修复问题）
- [ ] 新功能（非破坏性更改，增加新功能）
- [ ] 其他（未在以上列出的更改）

## 清单

<!-- 提交 PR 前请遵循以下清单，并在完成项目前加上 [x]。也可以在创建 PR 后补充。此清单用于帮助我们在合并前进行检查。 -->

- [ ] 我已阅读 [贡献指南](https://github.com/satnaing/shadcn-admin/blob/main/.github/CONTRIBUTING.md)

## 进一步说明

<!-- 如果这是较大或复杂的变更，请解释你为何选择该方案，以及你考虑过的替代方案等。 -->

## 关联的 Issue

<!-- 如果此 PR 与现有 Issue 相关，请在此处进行链接。 -->

关闭：#<!-- 相关 Issue 编号（如适用） -->